### PR TITLE
Topic/lambda abstractions

### DIFF
--- a/icicle-compiler/test/Icicle/Test/Arbitrary/Source.hs
+++ b/icicle-compiler/test/Icicle/Test/Arbitrary/Source.hs
@@ -343,9 +343,15 @@ genExp tgi
   primApps
    = do p <- arbitrary
         let ft = testFresh "" $ primLookup' p
-        let num = length $ functionArguments ft
+        let num = lengthFunctionArguments ft
         xs <- vectorOf num (genExp tgi)
         return $ foldl (App ()) (Prim () p) xs
+
+  lengthFunctionArguments t
+   = case t of
+      TypeForall _ _ x -> lengthFunctionArguments x
+      TypeArrow _ x -> 1 + lengthFunctionArguments x
+      _ -> 0
 
 
 genCase :: TypedGenInfo -> Gen (Pattern T.Variable, Exp () T.Variable)

--- a/icicle-compiler/test/Icicle/Test/Arbitrary/Source.hs
+++ b/icicle-compiler/test/Icicle/Test/Arbitrary/Source.hs
@@ -342,14 +342,14 @@ genExp tgi
 
   primApps
    = do p <- arbitrary
-        let ft = testFresh "" $ primLookup' p
+        let ft  = testFresh "" $ primLookup' p
         let num = lengthFunctionArguments ft
-        xs <- vectorOf num (genExp tgi)
+        xs     <- vectorOf num (genExp tgi)
         return $ foldl (App ()) (Prim () p) xs
 
   lengthFunctionArguments t
    = case t of
-      TypeForall _ _ x -> lengthFunctionArguments x
+      TypeForall _ _ x  -> lengthFunctionArguments x
       TypeArrow _ x -> 1 + lengthFunctionArguments x
       _ -> 0
 

--- a/icicle-compiler/test/Icicle/Test/Core/Exp/Simp.hs
+++ b/icicle-compiler/test/Icicle/Test/Core/Exp/Simp.hs
@@ -85,7 +85,7 @@ prop_core_simp_type = property $ do
   typeExp0 coreFragment x === typeExp0 coreFragment simple
 
 -- Core simplification preserves result
-prop_core_simp_eval = withTests 10000 $ property $ do
+prop_core_simp_eval = withTests 1000 $ property $ do
   x <- forAll (fst <$> genExpTop)
   annotate (show . pretty $ x)
   let x' = snd

--- a/icicle-compiler/test/Icicle/Test/Source/Progress.hs
+++ b/icicle-compiler/test/Icicle/Test/Source/Progress.hs
@@ -29,7 +29,7 @@ import qualified Data.Map as Map
 
 
 mkElems :: Map.Map (CB.Name T.Variable) CT.ValType -> CheckEnv () T.Variable
-mkElems m = emptyCheckEnv { checkEnvironment = Map.map (function0 . Temporality TemporalityElement . Possibility PossibilityDefinitely . typeOfValType) m }
+mkElems m = emptyCheckEnv { checkEnvironment = Map.map (Temporality TemporalityElement . Possibility PossibilityDefinitely . typeOfValType) m }
 
 prop_progress_no_values :: Map.Map (CB.Name T.Variable) CT.ValType -> Query () T.Variable -> Property
 prop_progress_no_values f q

--- a/icicle-compiler/test/cli/repl/t01-sanity/expected
+++ b/icicle-compiler/test/cli/repl/t01-sanity/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t01.2-trig/expected
+++ b/icicle-compiler/test/cli/repl/t01.2-trig/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t02-groups/expected
+++ b/icicle-compiler/test/cli/repl/t02-groups/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t02.1-group-groups/expected
+++ b/icicle-compiler/test/cli/repl/t02.1-group-groups/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -15,7 +15,7 @@ Selected psv file as input: test/cli/repl/data.psv
      ░            ░
                   ░     :help for help
 
-λ Loaded dictionary with 1 inputs, 0 outputs, 74 functions.
+λ Loaded dictionary with 1 inputs, 0 outputs, 70 functions.
 λ Selected psv file as input: test/cli/repl/t02.1-group-groups/data.psv
 λ Snapshot mode activated with a snapshot date of 2016-07-14.
 λ Queries will be evaluated using the core evaluator.

--- a/icicle-compiler/test/cli/repl/t03-distinct/expected
+++ b/icicle-compiler/test/cli/repl/t03-distinct/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t03.1-distinct-tomb/expected
+++ b/icicle-compiler/test/cli/repl/t03.1-distinct-tomb/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -15,7 +15,7 @@ Selected psv file as input: test/cli/repl/data.psv
      ░            ░
                   ░     :help for help
 
-λ Loaded dictionary with 4 inputs, 4 outputs, 74 functions.
+λ Loaded dictionary with 4 inputs, 4 outputs, 70 functions.
 λ Selected psv file as input: test/cli/repl/data-tomb.psv
 λ λ -- Try all combinations of Possibly: 'time' is definitely, while 'location' is possibly.
 λ Core evaluation

--- a/icicle-compiler/test/cli/repl/t04-lets/expected
+++ b/icicle-compiler/test/cli/repl/t04-lets/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t05-nested-queries/expected
+++ b/icicle-compiler/test/cli/repl/t05-nested-queries/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t06-custom-folds/expected
+++ b/icicle-compiler/test/cli/repl/t06-custom-folds/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t07-possiblies/expected
+++ b/icicle-compiler/test/cli/repl/t07-possiblies/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t08-randomly/expected
+++ b/icicle-compiler/test/cli/repl/t08-randomly/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t09-group-folds/expected
+++ b/icicle-compiler/test/cli/repl/t09-group-folds/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t10-avalanche/expected
+++ b/icicle-compiler/test/cli/repl/t10-avalanche/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t10.2-core/expected
+++ b/icicle-compiler/test/cli/repl/t10.2-core/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t10.3-flatten/expected
+++ b/icicle-compiler/test/cli/repl/t10.3-flatten/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t11-nested-dictionaries/expected
+++ b/icicle-compiler/test/cli/repl/t11-nested-dictionaries/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -16,5 +16,5 @@ Selected psv file as input: test/cli/repl/data.psv
                   ░     :help for help
 
 λ -- Load dictionary
-λ Loaded dictionary with 4 inputs, 4 outputs, 74 functions.
+λ Loaded dictionary with 4 inputs, 4 outputs, 70 functions.
 λ 

--- a/icicle-compiler/test/cli/repl/t12-broken-dictionaries/expected
+++ b/icicle-compiler/test/cli/repl/t12-broken-dictionaries/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t13-cases-either/expected
+++ b/icicle-compiler/test/cli/repl/t13-cases-either/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t14-dates/expected
+++ b/icicle-compiler/test/cli/repl/t14-dates/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t15-tombstones/expected
+++ b/icicle-compiler/test/cli/repl/t15-tombstones/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -15,7 +15,7 @@ Selected psv file as input: test/cli/repl/data.psv
      ░            ░
                   ░     :help for help
 
-λ Loaded dictionary with 1 inputs, 0 outputs, 74 functions.
+λ Loaded dictionary with 1 inputs, 0 outputs, 70 functions.
 λ Selected psv file as input: test/cli/repl/t15-tombstones/data.psv
 λ λ Core evaluation
 ---------------

--- a/icicle-compiler/test/cli/repl/t16-prelude/expected
+++ b/icicle-compiler/test/cli/repl/t16-prelude/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -56,7 +56,7 @@ C evaluation
 homer|300.0
 marge|10.0
 
-λ λ -- minby / min example
+λ λ -- min_by / min example
 λ Core evaluation
 ---------------
 
@@ -67,7 +67,7 @@ C evaluation
 
 homer|("head", 1)
 
-λ λ -- maxby / max example
+λ λ -- max_by / max example
 λ Core evaluation
 ---------------
 

--- a/icicle-compiler/test/cli/repl/t16-prelude/script
+++ b/icicle-compiler/test/cli/repl/t16-prelude/script
@@ -10,11 +10,11 @@ feature salary ~> count value
 -- Mean example
 feature salary ~> mean value
 
--- minby / min example
-feature injury ~> minby severity location , min severity
+-- min_by / min example
+feature injury ~> min_by severity location , min severity
 
--- maxby / max example
-feature injury ~> maxby severity location , max severity
+-- max_by / max example
+feature injury ~> max_by severity location , max severity
 
 -- Standard deviation example
 feature salary ~> sd value
@@ -36,9 +36,9 @@ feature injury ~> numflips location
 feature injury ~> numflips' location tombstone
 
 -- IsSome
-feature salary ~> latest 1 ~> isSome (Some "hi")
+feature salary ~> latest 1 ~> is_some (Some "hi")
 -- IsNone
-feature salary ~> latest 1 ~> isNone (Some "hi")
+feature salary ~> latest 1 ~> is_none (Some "hi")
 
 --GetOrElse example
-feature salary ~> getOrElse 3 (Some (newest value))
+feature salary ~> get_or_else 3 (Some (newest value))

--- a/icicle-compiler/test/cli/repl/t17-latest/expected
+++ b/icicle-compiler/test/cli/repl/t17-latest/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t18-nested-structs/expected
+++ b/icicle-compiler/test/cli/repl/t18-nested-structs/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -17,7 +17,7 @@ Selected psv file as input: test/cli/repl/data.psv
 
 λ Queries will be evaluated using the core evaluator.
 λ Queries will be evaluated using the C evaluator.
-λ λ Loaded dictionary with 1 inputs, 0 outputs, 74 functions.
+λ λ Loaded dictionary with 1 inputs, 0 outputs, 70 functions.
 λ Selected psv file as input: test/cli/repl/t18-nested-structs/data.psv
 λ λ Core evaluation
 ---------------

--- a/icicle-compiler/test/cli/repl/t19-windows/expected
+++ b/icicle-compiler/test/cli/repl/t19-windows/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t20-lexer/expected
+++ b/icicle-compiler/test/cli/repl/t20-lexer/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t30-sea/expected
+++ b/icicle-compiler/test/cli/repl/t30-sea/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t30.1-eval/expected
+++ b/icicle-compiler/test/cli/repl/t30.1-eval/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t30.2-array-strings/expected
+++ b/icicle-compiler/test/cli/repl/t30.2-array-strings/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -17,7 +17,7 @@ Selected psv file as input: test/cli/repl/data.psv
 
 λ -- Enable C evaluation
 λ Queries will be evaluated using the C evaluator.
-λ λ Loaded dictionary with 2 inputs, 0 outputs, 74 functions.
+λ λ Loaded dictionary with 2 inputs, 0 outputs, 70 functions.
 λ Selected psv file as input: test/cli/repl/t30.2-array-strings/data.psv
 λ λ Core evaluation
 ---------------

--- a/icicle-compiler/test/cli/repl/t30.3-sum-not-error/expected
+++ b/icicle-compiler/test/cli/repl/t30.3-sum-not-error/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t30.4-array-updates/expected
+++ b/icicle-compiler/test/cli/repl/t30.4-array-updates/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -17,7 +17,7 @@ Selected psv file as input: test/cli/repl/data.psv
 
 λ Queries will be evaluated using the C evaluator.
 λ Queries will be evaluated using the core evaluator.
-λ λ Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+λ λ Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 λ Selected psv file as input: test/cli/repl/t30.4-array-updates/data.psv
 λ λ Core evaluation
 ---------------

--- a/icicle-compiler/test/cli/repl/t31-builtin/expected
+++ b/icicle-compiler/test/cli/repl/t31-builtin/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -15,7 +15,7 @@ Selected psv file as input: test/cli/repl/data.psv
      ░            ░
                   ░     :help for help
 
-λ Loaded dictionary with 4 inputs, 4 outputs, 74 functions.
+λ Loaded dictionary with 4 inputs, 4 outputs, 70 functions.
 λ Selected psv file as input: data/example/demographics.psv
 λ Queries will be evaluated using the core evaluator.
 λ Queries will be evaluated using the C evaluator.
@@ -175,7 +175,7 @@ homer|( tombstone
         , 2191
         ] )
 
-λ λ Loaded dictionary with 1 inputs, 0 outputs, 74 functions.
+λ λ Loaded dictionary with 1 inputs, 0 outputs, 70 functions.
 λ Selected psv file as input: test/cli/repl/t31-builtin/data.psv
 λ λ -- NY should be 1 year, CA should be 4 years, OR should be 1 year
 λ Core evaluation

--- a/icicle-compiler/test/cli/repl/t31-builtin/script
+++ b/icicle-compiler/test/cli/repl/t31-builtin/script
@@ -5,11 +5,11 @@
 
 feature injury ~> group_keys location
 
-feature injury ~> days between (newest (box admitted)) now
+feature injury ~> days between (newest (get admitted)) now
 
 -- These were errors picked up by QuickCheck
-feature injury ~> box (Some now)
-feature injury ~> newest (box None)
+feature injury ~> get (Some now)
+feature injury ~> newest (get None)
 
 feature salary ~> let x = (latest 3 ~> value) ~> sort x
 

--- a/icicle-compiler/test/cli/repl/t40-bigdata/expected
+++ b/icicle-compiler/test/cli/repl/t40-bigdata/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -93,7 +93,7 @@ Error
 
 ## Check error
 
-  For resumable queries, folds, groups and distincts must be inside windowed or latest at 54:9:prelude.icicle
+  For resumable queries, folds, groups and distincts must be inside windowed or latest at 56:9:prelude.icicle
   
   Fold: fold s =
           0 : value + s
@@ -111,7 +111,7 @@ Error
 
 ## Check error
 
-  For resumable queries, folds, groups and distincts must be inside windowed or latest at 54:9:prelude.icicle
+  For resumable queries, folds, groups and distincts must be inside windowed or latest at 56:9:prelude.icicle
   
   Fold: fold s =
           0 : value + s
@@ -130,7 +130,7 @@ Error
 
 ## Check error
 
-  For resumable queries, folds, groups and distincts must be inside windowed or latest at 54:9:prelude.icicle
+  For resumable queries, folds, groups and distincts must be inside windowed or latest at 56:9:prelude.icicle
   
   Fold: fold s =
           0 : value + s
@@ -199,7 +199,7 @@ Error
 
 ## Check error
 
-  For resumable queries, folds, groups and distincts must be inside windowed or latest at 54:9:prelude.icicle
+  For resumable queries, folds, groups and distincts must be inside windowed or latest at 56:9:prelude.icicle
   
   Fold: fold s =
           0 : value + s
@@ -217,7 +217,7 @@ Error
 
 ## Check error
 
-  For resumable queries, folds, groups and distincts must be inside windowed or latest at 54:9:prelude.icicle
+  For resumable queries, folds, groups and distincts must be inside windowed or latest at 56:9:prelude.icicle
   
   Fold: fold s =
           0 : x + s

--- a/icicle-compiler/test/cli/repl/t50-psv-many-rows/expected
+++ b/icicle-compiler/test/cli/repl/t50-psv-many-rows/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t60-map-delete/expected
+++ b/icicle-compiler/test/cli/repl/t60-map-delete/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t60.1-map-insert/expected
+++ b/icicle-compiler/test/cli/repl/t60.1-map-insert/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████

--- a/icicle-compiler/test/cli/repl/t61-bad-names/expected
+++ b/icicle-compiler/test/cli/repl/t61-bad-names/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -15,7 +15,7 @@ Selected psv file as input: test/cli/repl/data.psv
      ░            ░
                   ░     :help for help
 
-λ Loaded dictionary with 2 inputs, 0 outputs, 74 functions.
+λ Loaded dictionary with 2 inputs, 0 outputs, 70 functions.
 λ Selected psv file as input: test/cli/repl/t61-bad-names/data.psv
 λ Queries will be evaluated using the core evaluator.
 λ Queries will be evaluated using the C evaluator.

--- a/icicle-compiler/test/cli/repl/t70-zebra/expected
+++ b/icicle-compiler/test/cli/repl/t70-zebra/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -17,7 +17,7 @@ Selected psv file as input: test/cli/repl/data.psv
 
 λ -- Load a zebra file
 λ Loaded dictionary with 1 inputs, 0 outputs, 33 functions.
-Loaded 74 functions from prelude.icicle
+Loaded 70 functions from prelude.icicle
 Selected zebra binary file as input: data/example/sample.zbin
 λ Queries will be evaluated using the C evaluator.
 λ Snapshot mode activated with a snapshot date of 2016-02-01.

--- a/icicle-compiler/test/cli/repl/t80-array-index/expected
+++ b/icicle-compiler/test/cli/repl/t80-array-index/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -15,7 +15,7 @@ Selected psv file as input: test/cli/repl/data.psv
      ░            ░
                   ░     :help for help
 
-λ Loaded dictionary with 5 inputs, 0 outputs, 74 functions.
+λ Loaded dictionary with 5 inputs, 0 outputs, 70 functions.
 λ Selected psv file as input: test/cli/repl/data.psv
 λ λ -- Valid indices
 λ Core evaluation

--- a/icicle-compiler/test/cli/repl/t80-array-index/script
+++ b/icicle-compiler/test/cli/repl/t80-array-index/script
@@ -17,8 +17,8 @@ feature salary ~> let arr = (latest 3 ~> value) ~> index arr (-1)
 feature salary ~> let arr = (latest 3 ~> time) ~> let a = index arr 2 ~> days a
 
 -- Array is Possibly of Definitely
-feature salary ~> let arr = box (Some (latest 3 ~> time)) ~> let a = index arr 2 ~> days a
+feature salary ~> let arr = box (Right (latest 3 ~> time)) ~> let a = index arr 2 ~> days a
 
 -- Array is Possibly of Possibly
-feature salary ~> let arr = box (Some (latest 3 ~> value)) ~> let a = index arr 2 ~> a
+feature salary ~> let arr = box (Right (latest 3 ~> value)) ~> let a = index arr 2 ~> a
 

--- a/icicle-source/src/Icicle/Compiler/Source.hs
+++ b/icicle-source/src/Icicle/Compiler/Source.hs
@@ -280,7 +280,7 @@ sourceInline :: Inline.InlineOption
              -> QueryTyped   Var
              -> QueryUntyped Var
 sourceInline opt d q
- = Query.reannotQT Type.annAnnot
+ = Query.reannot Type.annAnnot
  $ inline q
  where
   funs      = M.fromList

--- a/icicle-source/src/Icicle/Source/Checker/Base.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Base.hs
@@ -248,9 +248,7 @@ introForalls ann f
                $ cs
 
       let sub   = substT freshen
-      return ( f
-             , sub x
-             , cons )
+      return (f, sub x, cons)
 
     _ ->
       return (f, f, [])

--- a/icicle-source/src/Icicle/Source/Checker/Base.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Base.hs
@@ -68,7 +68,7 @@ import           Control.Monad.Trans.State.Lazy
 data CheckEnv a n
  = CheckEnv {
  -- | Mapping from variable names to whole types
-   checkEnvironment :: Map.Map (Name n) (FunctionType n)
+   checkEnvironment :: Map.Map (Name n) (Type n)
  -- | Function bodies
  , checkBodies      :: Map.Map (Name n) (Function a n)
  , checkInvariants  :: Invariants
@@ -116,7 +116,7 @@ defaultCheckOptions = optionSmallData
 --------------------------------------------------------------------------------
 
 
-type GenEnv n             = Map.Map (Name n) (FunctionType n)
+type GenEnv n             = Map.Map (Name n) (Type n)
 type GenConstraintSet a n = [(a, Constraint n)]
 
 data DischargeInfo a n = DischargeInfo
@@ -231,13 +231,15 @@ fresh
 
 -- | Freshen function type by applying introduction rules to foralls.
 --
+-- This only works at the top level, which is fine for now, but might
+-- start becoming a challenge when the type system grows.
 introForalls
   :: (Hashable n, Eq n)
   => a
-  -> FunctionType n
-  -> Gen a n (FunctionType n, Type n, GenConstraintSet a n)
+  -> Type n
+  -> Gen a n (Type n, Type n, GenConstraintSet a n)
 introForalls ann f
- = case functionReturn f of
+ = case f of
     TypeForall ns cs x -> do
       freshen <- Map.fromList <$> mapM mkSubst ns
 
@@ -265,7 +267,7 @@ lookup
   => a
   -> Name n
   -> GenEnv n
-  -> Gen a n (FunctionType n, Type n, GenConstraintSet a n)
+  -> Gen a n (Type n, Type n, GenConstraintSet a n)
 lookup ann n env
  = case Map.lookup n env of
      Just t
@@ -278,7 +280,7 @@ lookup ann n env
 -- | Bind a new to a type in the given context.
 bindT :: Eq n => Name n -> Type n -> GenEnv n -> GenEnv n
 bindT n t
- = Map.insert n (function0 t)
+ = Map.insert n t
 
 -- | Temporarily add the binding to a context, then do something.
 withBind
@@ -297,12 +299,12 @@ removeElementBinds env
    in  foldr Map.delete env elts
  where
   isElementTemporality ft
-   = getTemporalityOrPure (functionReturn ft) == TemporalityElement
+   = getTemporalityOrPure ft == TemporalityElement
 
 
 substE :: Eq n => SubstT n -> GenEnv n -> GenEnv n
 substE s
- = fmap (substFT s)
+ = fmap (substT s)
 
 substTQ :: (Hashable n, Eq n) => SubstT n -> Query'C a n -> Query'C a n
 substTQ s

--- a/icicle-source/src/Icicle/Source/Checker/Base.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Base.hs
@@ -235,7 +235,7 @@ introForalls
   :: (Hashable n, Eq n)
   => a
   -> FunctionType n
-  -> Gen a n (FunctionType n, [Type n], Type n, GenConstraintSet a n)
+  -> Gen a n (FunctionType n, Type n, GenConstraintSet a n)
 introForalls ann f
  = do freshen <- Map.fromList <$> mapM mkSubst (functionForalls f)
 
@@ -245,8 +245,7 @@ introForalls ann f
 
       let sub   = substT freshen
       return ( f
-             , fmap sub $ functionArguments f
-             ,      sub $ functionReturn    f
+             , sub $ functionReturn    f
              , cons )
  where
   mkSubst n
@@ -260,7 +259,7 @@ lookup
   => a
   -> Name n
   -> GenEnv n
-  -> Gen a n (FunctionType n, [Type n], Type n, GenConstraintSet a n)
+  -> Gen a n (FunctionType n, Type n, GenConstraintSet a n)
 lookup ann n env
  = case Map.lookup n env of
      Just t

--- a/icicle-source/src/Icicle/Source/Checker/Base.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Base.hs
@@ -237,16 +237,22 @@ introForalls
   -> FunctionType n
   -> Gen a n (FunctionType n, Type n, GenConstraintSet a n)
 introForalls ann f
- = do freshen <- Map.fromList <$> mapM mkSubst (functionForalls f)
+ = case functionReturn f of
+    TypeForall ns cs x -> do
+      freshen <- Map.fromList <$> mapM mkSubst ns
 
       let cons = concat
                $ fmap (require ann . substC freshen)
-               $ functionConstraints f
+               $ cs
 
       let sub   = substT freshen
       return ( f
-             , sub $ functionReturn    f
+             , sub x
              , cons )
+
+    elsewise ->
+      return (f, elsewise, [])
+
  where
   mkSubst n
    = ((,) n . TypeVar) <$> fresh

--- a/icicle-source/src/Icicle/Source/Checker/Base.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Base.hs
@@ -302,11 +302,11 @@ substE s
 
 substTQ :: (Hashable n, Eq n) => SubstT n -> Query'C a n -> Query'C a n
 substTQ s
- = reannotQ (substAnnot s)
+ = reannot (substAnnot s)
 
 substTX :: (Hashable n, Eq n) => SubstT n -> Exp'C a n -> Exp'C a n
 substTX s
- = reannotX (substAnnot s)
+ = reannot (substAnnot s)
 
 substAnnot :: (Hashable n, Eq n) => SubstT n -> Annot a n -> Annot a n
 substAnnot s ann

--- a/icicle-source/src/Icicle/Source/Checker/Base.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Base.hs
@@ -252,8 +252,8 @@ introForalls ann f
              , sub x
              , cons )
 
-    elsewise ->
-      return (f, elsewise, [])
+    _ ->
+      return (f, f, [])
 
  where
   mkSubst n

--- a/icicle-source/src/Icicle/Source/Checker/Base.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Base.hs
@@ -242,12 +242,8 @@ introForalls ann f
  = case f of
     TypeForall ns cs x -> do
       freshen <- Map.fromList <$> mapM mkSubst ns
-
-      let cons = concat
-               $ fmap (require ann . substC freshen)
-               $ cs
-
-      let sub   = substT freshen
+      let cons = concatMap (require ann . substC freshen) cs
+      let sub  = substT freshen
       return (f, sub x, cons)
 
     _ ->

--- a/icicle-source/src/Icicle/Source/Checker/Checker.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Checker.hs
@@ -45,9 +45,9 @@ checkQT opts features qt
   = case lookupInputId (queryInput qt) (featuresConcretes features) of
     Just (FeatureConcrete _ _ f)
      -> do  let env = Map.unions
-                      [ fmap function0 (envOfFeatureContext f)
+                      [ envOfFeatureContext f
                       , featuresFunctions features
-                      , fmap function0 (envOfFeatureNow opts (featureNow features)) ]
+                      , envOfFeatureNow opts (featureNow features) ]
             (q,t) <- checkQ opts (emptyCheckEnv { checkEnvironment = env }) (query qt)
             return (qt { query = q }, t)
 

--- a/icicle-source/src/Icicle/Source/Checker/Checker.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Checker.hs
@@ -25,6 +25,7 @@ import qualified        Icicle.Common.Fresh     as Fresh
 
 import                  P
 
+
 import qualified        Data.Map as Map
 import                  Data.Hashable (Hashable)
 
@@ -81,8 +82,14 @@ checkQ opts ctx q
        _
          -> hoistEither
           $ errorSuggestions
-              (ErrorReturnNotAggregate (annotOfQuery $ q) t)
+              (ErrorReturnNotAggregate (annotOfQuery q) t)
               [Suggest "The return must be an aggregate, otherwise the result could be quite large"]
+
+      when (anyArrows t)
+        $ hoistEither
+        $ errorSuggestions
+            (ErrorReturnNotAggregate (annotOfQuery q) t)
+            [Suggest "The return must not contain functions or type abstractions"]
 
       hoistEither $ invariantQ ctx q
 
@@ -90,4 +97,3 @@ checkQ opts ctx q
         hoistEither $ checkResumableQ ctx q
 
       return (q', t)
-

--- a/icicle-source/src/Icicle/Source/Checker/Checker.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Checker.hs
@@ -25,7 +25,6 @@ import qualified        Icicle.Common.Fresh     as Fresh
 
 import                  P
 
-
 import qualified        Data.Map as Map
 import                  Data.Hashable (Hashable)
 

--- a/icicle-source/src/Icicle/Source/Checker/Constraint.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Constraint.hs
@@ -794,8 +794,8 @@ generateP ann scrutTy resTy resTmTop resTm resPs ((pat, alt):rest) env
         return ( SumT l r , c, e' )
 
   goPat (PatLit l _) e
-   = do FunctionType _foralls constraints resT <- Gen . lift . lift $ primLookup' (Lit l)
-        return (resT, fmap (ann,) constraints, e)
+   = do FunctionType resT <- Gen . lift . lift $ primLookup' (Lit l)
+        return (resT, [], e)
 
   goPat _ _
    = genHoistEither

--- a/icicle-source/src/Icicle/Source/Checker/Constraint.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Constraint.hs
@@ -25,8 +25,6 @@ import           Icicle.Internal.Pretty       (Pretty)
 
 import           P hiding (with)
 
-import           Control.Monad.Trans.Class    (lift)
-
 import           Data.Hashable                (Hashable)
 import           Data.List                    (unzip3)
 import qualified Data.Map                     as Map
@@ -794,8 +792,8 @@ generateP ann scrutTy resTy resTmTop resTm resPs ((pat, alt):rest) env
         return ( SumT l r , c, e' )
 
   goPat (PatLit l _) e
-   = do resT <- Gen . lift . lift $ primLookup' (Lit l)
-        return (resT, [], e)
+   = do (_, resT, cons) <- primLookup ann (Lit l)
+        return (resT, cons, e)
 
   goPat _ _
    = genHoistEither

--- a/icicle-source/src/Icicle/Source/Checker/Constraint.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Constraint.hs
@@ -143,7 +143,7 @@ defaults topq
 --   We take the map of types of all imported functions.
 constraintsQ
   :: (Hashable n, Eq n, Pretty n)
-  => Map.Map (Name n) (FunctionType n)
+  => Map.Map (Name n) (Type n)
   -> Query a n
   -> EitherT (CheckError a n) (Fresh.Fresh n) (Query'C a n)
 constraintsQ env q
@@ -794,7 +794,7 @@ generateP ann scrutTy resTy resTmTop resTm resPs ((pat, alt):rest) env
         return ( SumT l r , c, e' )
 
   goPat (PatLit l _) e
-   = do FunctionType resT <- Gen . lift . lift $ primLookup' (Lit l)
+   = do resT <- Gen . lift . lift $ primLookup' (Lit l)
         return (resT, [], e)
 
   goPat _ _

--- a/icicle-source/src/Icicle/Source/Checker/Constraint.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Constraint.hs
@@ -567,11 +567,11 @@ generateX x env
  =<< case x of
     -- Variables can only be values, not functions.
     Var a n
-     -> do (_fErr, resT, cons') <- lookup a n env
+     -> do (fErr, resT, cons') <- lookup a n env
 
            when (isFunction resT)
              $ genHoistEither
-             $ errorNoSuggestions (ErrorFunctionWrongArgs a x resT [])
+             $ errorNoSuggestions (ErrorFunctionWrongArgs a x fErr [])
 
            let x' = annotate cons' resT
                   $ \a' -> Var a' n
@@ -617,7 +617,7 @@ generateX x env
                              rs        <- genXs xs (substE s env')
                              return ((xx',s,c) : rs)
 
-        in do   (_fErr, resT, consf)        <- look
+        in do   (fErr, resT, consf)        <- look
 
                 (args', subs', consxs)     <- unzip3 <$> genXs args env
                 let argsT'                  = fmap (annResult.annotOfExp) args'
@@ -627,7 +627,7 @@ generateX x env
 
                 when (isFunction resT')
                   $ genHoistEither
-                  $ errorNoSuggestions (ErrorFunctionWrongArgs a x resT [])
+                  $ errorNoSuggestions (ErrorFunctionWrongArgs a x fErr [])
 
                 let s' = foldl compose Map.empty subs'
                 let cons' = concat (consf : consap : consxs)
@@ -638,11 +638,11 @@ generateX x env
 
     -- Unapplied primitives should be relatively easy
     Prim a p
-     -> do (_fErr, resT, cons') <- primLookup a p
+     -> do (fErr, resT, cons') <- primLookup a p
 
            when (isFunction resT)
               $ genHoistEither
-              $ errorNoSuggestions (ErrorFunctionWrongArgs a x resT [])
+              $ errorNoSuggestions (ErrorFunctionWrongArgs a x fErr [])
 
            let x' = annotate cons' resT
                   $ \a' -> Prim a' p

--- a/icicle-source/src/Icicle/Source/Checker/Constraint.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Constraint.hs
@@ -630,7 +630,7 @@ generateX x env
                 let s' = foldl compose Map.empty subs'
                 let cons' = concat (consf : consap : consxs)
 
-                let f' = annotate cons' resT' $ \a' -> reannotX (const a') f
+                let f' = annotate cons' resT' $ \a' -> reannot (const a') f
 
                 return (foldl mkApp f' args', s', cons')
 

--- a/icicle-source/src/Icicle/Source/Checker/Error.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Error.hs
@@ -176,7 +176,7 @@ instance (IsString n, Pretty a, Pretty n, Hashable n, Eq n) => Pretty (ErrorInfo
 
     ErrorReturnNotAggregate a t ->
       vsep [
-          "Return type is not an aggregate at" <+> pretty a
+          "Return type is not an aggregate value at" <+> pretty a
         , mempty
         , "Type: " <> inp t
         ]

--- a/icicle-source/src/Icicle/Source/Checker/Error.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Error.hs
@@ -41,7 +41,7 @@ data ErrorInfo a n
  = ErrorNoSuchVariable a (Name n)
  | ErrorNoSuchInput a UnresolvedInputId
  | ErrorContextNotAllowedHere  a (Context a n)
- | ErrorFunctionWrongArgs      a (Type n) (Type n)
+ | ErrorFunctionWrongArgs      a (Exp a n) (Type n) [Type n]
  | ErrorApplicationNotFunction a (Exp a n)
  | ErrorConstraintsNotSatisfied a [(a, DischargeError n)]
  | ErrorConstraintLeftover      a [(a, Constraint n)]
@@ -65,7 +65,7 @@ annotOfError (CheckError e _)
      -> Just a
     ErrorContextNotAllowedHere  a _
      -> Just a
-    ErrorFunctionWrongArgs      a _ _
+    ErrorFunctionWrongArgs      a _ _ _
      -> Just a
     ErrorApplicationNotFunction a _
      -> Just a
@@ -144,10 +144,11 @@ instance (IsString n, Pretty a, Pretty n, Hashable n, Eq n) => Pretty (ErrorInfo
         , "Context: " <> inp c
         ]
 
-    ErrorFunctionWrongArgs a f tys ->
+    ErrorFunctionWrongArgs a x f tys ->
       vsep [
           "Function applied to wrong number of arguments at" <+> pretty a
         , mempty
+        , "Expression:     " <> inp x
         , "Function type:  " <> inp f
         , "Argument types: " <> inp tys
         ]

--- a/icicle-source/src/Icicle/Source/Checker/Error.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Error.hs
@@ -91,7 +91,7 @@ annotOfError (CheckError e _)
 
 data ErrorSuggestion a n
  = AvailableFeatures UnresolvedInputId [(InputId, Type n)]
- | AvailableBindings (Name n) [(Name n, FunctionType n)]
+ | AvailableBindings (Name n) [(Name n, Type n)]
  | Suggest String
  deriving (Show, Eq, Generic)
 
@@ -149,7 +149,7 @@ instance (IsString n, Pretty a, Pretty n, Hashable n, Eq n) => Pretty (ErrorInfo
           "Function applied to wrong number of arguments at" <+> pretty a
         , mempty
         , "Expression:     " <> inp x
-        , "Function type:  " <> inp f
+        , "Function type:  " <> inp (prettyFunFromStrings f)
         , "Argument types: " <> inp tys
         ]
 

--- a/icicle-source/src/Icicle/Source/Checker/Error.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Error.hs
@@ -41,7 +41,7 @@ data ErrorInfo a n
  = ErrorNoSuchVariable a (Name n)
  | ErrorNoSuchInput a UnresolvedInputId
  | ErrorContextNotAllowedHere  a (Context a n)
- | ErrorFunctionWrongArgs      a (Exp a n) (FunctionType n) [Type n]
+ | ErrorFunctionWrongArgs      a (Type n) (Type n)
  | ErrorApplicationNotFunction a (Exp a n)
  | ErrorConstraintsNotSatisfied a [(a, DischargeError n)]
  | ErrorConstraintLeftover      a [(a, Constraint n)]
@@ -65,7 +65,7 @@ annotOfError (CheckError e _)
      -> Just a
     ErrorContextNotAllowedHere  a _
      -> Just a
-    ErrorFunctionWrongArgs      a _ _ _
+    ErrorFunctionWrongArgs      a _ _
      -> Just a
     ErrorApplicationNotFunction a _
      -> Just a
@@ -144,12 +144,11 @@ instance (IsString n, Pretty a, Pretty n, Hashable n, Eq n) => Pretty (ErrorInfo
         , "Context: " <> inp c
         ]
 
-    ErrorFunctionWrongArgs a x f tys ->
+    ErrorFunctionWrongArgs a f tys ->
       vsep [
           "Function applied to wrong number of arguments at" <+> pretty a
         , mempty
-        , "Expression:     " <> inp x
-        , "Function type:  " <> inp (prettyFunFromStrings f)
+        , "Function type:  " <> inp f
         , "Argument types: " <> inp tys
         ]
 

--- a/icicle-source/src/Icicle/Source/Checker/Function.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Function.hs
@@ -49,10 +49,10 @@ checkFs env functions
     else pure (env0 <> [ResolvedFunction (snd name) funtype annotfun], logs0 <> [logs'])
 
 checkF  :: (Hashable n, Eq n, Pretty n)
-        => Map.Map (Name n) (FunctionType n)
+        => Map.Map (Name n) (Type n)
         -> Function a n
         -> EitherT (CheckError a n) (Fresh.Fresh n)
-                   ((Function (Annot a n) n, FunctionType n), [CheckLog a n])
+                   ((Function (Annot a n) n, Type n), [CheckLog a n])
 
 checkF env fun
  = evalGen $ checkF' fun env
@@ -62,7 +62,7 @@ checkF env fun
 checkF' :: (Hashable n, Eq n, Pretty n)
         => Function a n
         -> GenEnv n
-        -> Gen a n (Function (Annot a n) n, FunctionType n)
+        -> Gen a n (Function (Annot a n) n, Type n)
 
 checkF' fun env
  = do -- Give each argument a fresh type variable
@@ -148,8 +148,7 @@ checkF' fun env
                 $ keepModes : freeT resT : fmap freeT argTs
 
       -- Put it all together
-      let funT  = FunctionType
-                $ TypeForall binds constrs
+      let funT  = TypeForall binds constrs
                 $ foldr TypeArrow resT argTs
 
       return (Function args q, funT)

--- a/icicle-source/src/Icicle/Source/Checker/Function.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Function.hs
@@ -163,7 +163,7 @@ checkF' fun env
    <*>                  (TypeVar <$> fresh))
 
   lookupArg subs e (a,n)
-   = do (_,t,_) <- lookup a n e
+   = do (_, t,_) <- lookup a n e
         return (Annot a (substT subs t) [], n)
 
   dischargeInfo q cons subs =

--- a/icicle-source/src/Icicle/Source/Checker/Function.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Function.hs
@@ -148,7 +148,9 @@ checkF' fun env
                 $ keepModes : freeT resT : fmap freeT argTs
 
       -- Put it all together
-      let funT  = FunctionType binds constrs $ foldr TypeArrow resT argTs
+      let funT  = FunctionType
+                $ TypeForall binds constrs
+                $ foldr TypeArrow resT argTs
 
       return (Function args q, funT)
  where

--- a/icicle-source/src/Icicle/Source/Checker/Function.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Function.hs
@@ -147,9 +147,13 @@ checkF' fun env
                 $ Set.unions
                 $ keepModes : freeT resT : fmap freeT argTs
 
+      let arrT  = foldr TypeArrow resT argTs
+
       -- Put it all together
-      let funT  = TypeForall binds constrs
-                $ foldr TypeArrow resT argTs
+      let funT  | null binds && null constrs
+                = arrT
+                | otherwise
+                = TypeForall binds constrs arrT
 
       return (Function args q, funT)
  where

--- a/icicle-source/src/Icicle/Source/Checker/Function.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Function.hs
@@ -148,7 +148,7 @@ checkF' fun env
                 $ keepModes : freeT resT : fmap freeT argTs
 
       -- Put it all together
-      let funT  = FunctionType binds constrs argTs resT
+      let funT  = FunctionType binds constrs $ foldr TypeArrow resT argTs
 
       return (Function args q, funT)
  where
@@ -162,7 +162,7 @@ checkF' fun env
    <*>                  (TypeVar <$> fresh))
 
   lookupArg subs e (a,n)
-   = do (_,_,t,_) <- lookup a n e
+   = do (_,t,_) <- lookup a n e
         return (Annot a (substT subs t) [], n)
 
   dischargeInfo q cons subs =

--- a/icicle-source/src/Icicle/Source/Checker/Prim.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Prim.hs
@@ -21,7 +21,7 @@ import                  P
 primLookup
  :: (Hashable n, Eq n)
  => a -> Prim
- -> Gen a n (FunctionType n, [Type n], Type n, GenConstraintSet a n)
+ -> Gen a n (FunctionType n, Type n, GenConstraintSet a n)
 primLookup ann p
  = do ft <- Gen . lift . lift $ primLookup' p
       introForalls ann ft

--- a/icicle-source/src/Icicle/Source/Checker/Prim.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Prim.hs
@@ -21,7 +21,7 @@ import                  P
 primLookup
  :: (Hashable n, Eq n)
  => a -> Prim
- -> Gen a n (FunctionType n, Type n, GenConstraintSet a n)
+ -> Gen a n (Type n, Type n, GenConstraintSet a n)
 primLookup ann p
  = do ft <- Gen . lift . lift $ primLookup' p
       introForalls ann ft

--- a/icicle-source/src/Icicle/Source/Parser/Constructor.hs
+++ b/icicle-source/src/Icicle/Source/Parser/Constructor.hs
@@ -60,7 +60,7 @@ constructors
 --   handled the same in the patterns as the expressions
 --   they match, and we don't have to duplicate parser
 --   logic.
-checkPat :: Monad m => Q.Exp T.SourcePos Var -> m (Q.Pattern Var)
+checkPat :: Monad m => Q.Exp pos Var -> m (Q.Pattern Var)
 checkPat exp =
   case exp of
     -- Variables are simple, just underscore default

--- a/icicle-source/src/Icicle/Source/Query/Builtin.hs
+++ b/icicle-source/src/Icicle/Source/Query/Builtin.hs
@@ -9,7 +9,6 @@ import           Icicle.Internal.Pretty
 
 import           P
 
-
 data BuiltinFun
  = BuiltinMath  !BuiltinMath
  | BuiltinText  !BuiltinText

--- a/icicle-source/src/Icicle/Source/Query/Context.hs
+++ b/icicle-source/src/Icicle/Source/Query/Context.hs
@@ -34,6 +34,18 @@ data Context' q a n
 
 instance (NFData (q a n), NFData a, NFData n) => NFData (Context' q a n)
 
+instance TraverseAnnot q => TraverseAnnot (Context' q)  where
+  traverseAnnot f cc =
+    case cc of
+      Windowed  a b c   -> Windowed  <$> f a <*> pure b <*> pure c
+      Latest    a i     -> Latest    <$> f a <*> pure i
+      GroupBy   a x     -> GroupBy   <$> f a <*> traverseAnnot f x
+      GroupFold a k v x -> GroupFold <$> f a <*> pure k <*> pure v <*> traverseAnnot f x
+      Distinct  a x     -> Distinct  <$> f a <*> traverseAnnot f x
+      Filter    a x     -> Filter    <$> f a <*> traverseAnnot f x
+      LetFold   a ff    -> LetFold   <$> f a <*> traverseAnnot f ff
+      Let      a n x    -> Let       <$> f a <*> pure n <*> traverseAnnot f x
+
 data Fold q a n
  = Fold
  { foldBind :: Pattern n
@@ -41,6 +53,13 @@ data Fold q a n
  , foldWork :: Exp' q a n
  , foldType :: FoldType }
  deriving (Show, Eq, Ord, Generic)
+
+instance TraverseAnnot q => TraverseAnnot (Fold q)  where
+  traverseAnnot f ff =
+    Fold (foldBind ff)
+      <$> traverseAnnot f (foldInit ff)
+      <*> traverseAnnot f (foldWork ff)
+      <*> pure            (foldType ff)
 
 instance (NFData (q a n), NFData a, NFData n) => NFData (Fold q a n)
 

--- a/icicle-source/src/Icicle/Source/Query/Exp.hs
+++ b/icicle-source/src/Icicle/Source/Query/Exp.hs
@@ -44,6 +44,7 @@ import           P
 
 data Exp' q a n
  = Var a (Name n)
+--  | Lam (Name n) (Exp' q a n)
  | Nested a (q a n)
  | App  a (Exp' q a n) (Exp' q a n)
  | Prim a Prim

--- a/icicle-source/src/Icicle/Source/Query/Function.hs
+++ b/icicle-source/src/Icicle/Source/Query/Function.hs
@@ -60,10 +60,6 @@ buildResolved :: (IsString n, Hashable n) => a -> BuiltinFun -> Fresh.Fresh n (R
 buildResolved a_fresh builtin = do
   typ
     <- primLookup' (Fun builtin)
-
-  args
-    <- return []
-
   let
     name
       = nameOf . NameBase . fromString . show . pretty $ builtin
@@ -71,12 +67,10 @@ buildResolved a_fresh builtin = do
       = Annot a_fresh typ []
     prim
       = Prim annot (Fun builtin)
-    exp'
-      = foldl (\ex (a, argName) -> mkApp ex (Var a argName)) prim args
     query'
-      = Query [] exp'
+      = Query [] prim
     definition
-      = Function args query'
+      = Function [] query'
 
   return $
     ResolvedFunction name typ definition

--- a/icicle-source/src/Icicle/Source/Query/Function.hs
+++ b/icicle-source/src/Icicle/Source/Query/Function.hs
@@ -5,7 +5,6 @@ module Icicle.Source.Query.Function (
     Function (..)
   , ResolvedFunction (..)
 
-  , reannotF
   , builtinDefinitions
   ) where
 
@@ -30,10 +29,10 @@ data Function a n
   , body      :: Query a n }
   deriving (Show, Eq)
 
-reannotF :: (a -> a') -> Function a n -> Function a' n
-reannotF f fun
- = fun { arguments = fmap (first f) (arguments fun)
-       , body = reannotQ f (body fun) }
+instance TraverseAnnot Function  where
+  traverseAnnot f fun =
+    Function <$> traverse (\(a, n) -> (,n) <$> f a) (arguments fun)
+             <*> traverseAnnot f (body fun)
 
 data ResolvedFunction a n =
   ResolvedFunction {

--- a/icicle-source/src/Icicle/Source/Query/Function.hs
+++ b/icicle-source/src/Icicle/Source/Query/Function.hs
@@ -67,10 +67,10 @@ buildResolved a_fresh builtin = do
   let
     name
       = nameOf . NameBase . fromString . show . pretty $ builtin
-    constraints
-      = (a_fresh,) <$> functionConstraints typ
+    -- constraints
+    --   = (a_fresh,) <$> functionConstraints typ
     annot
-      = Annot a_fresh (functionReturn typ) constraints
+      = Annot a_fresh (functionReturn typ) []
     prim
       = Prim annot (Fun builtin)
     exp'

--- a/icicle-source/src/Icicle/Source/Query/Function.hs
+++ b/icicle-source/src/Icicle/Source/Query/Function.hs
@@ -62,8 +62,7 @@ buildResolved a_fresh builtin = do
     <- primLookup' (Fun builtin)
 
   args
-    <- for (functionArguments typ) $ \ty -> do
-         (Annot a_fresh ty [],) <$> Fresh.fresh
+    <- return []
 
   let
     name

--- a/icicle-source/src/Icicle/Source/Query/Function.hs
+++ b/icicle-source/src/Icicle/Source/Query/Function.hs
@@ -38,7 +38,7 @@ reannotF f fun
 data ResolvedFunction a n =
   ResolvedFunction {
      functionName :: Name n
-   , functionType :: FunctionType n
+   , functionType :: Type n
    , functionDefinition :: Function (Annot a n) n
    } deriving (Eq, Show)
 
@@ -67,10 +67,8 @@ buildResolved a_fresh builtin = do
   let
     name
       = nameOf . NameBase . fromString . show . pretty $ builtin
-    -- constraints
-    --   = (a_fresh,) <$> functionConstraints typ
     annot
-      = Annot a_fresh (functionReturn typ) []
+      = Annot a_fresh typ []
     prim
       = Prim annot (Fun builtin)
     exp'

--- a/icicle-source/src/Icicle/Source/Query/Prim.hs
+++ b/icicle-source/src/Icicle/Source/Query/Prim.hs
@@ -183,7 +183,8 @@ primLookup' prim
 
  where
   functionType foralls constraints arguments simpleType
-   = FunctionType foralls constraints
+   = FunctionType
+   $ TypeForall foralls constraints
    $ foldr TypeArrow simpleType arguments
 
   f0 argsT resT

--- a/icicle-source/src/Icicle/Source/Query/Prim.hs
+++ b/icicle-source/src/Icicle/Source/Query/Prim.hs
@@ -22,7 +22,7 @@ import                  P
 import                  Data.Hashable (Hashable)
 
 
-primLookup' :: Hashable n => Prim -> Fresh.Fresh n (FunctionType n)
+primLookup' :: Hashable n => Prim -> Fresh.Fresh n (Type n)
 primLookup' prim
  = case prim of
     -- Negate on Doubles will not introduce NaN or Inf
@@ -182,9 +182,11 @@ primLookup' prim
      -> f0 [] ErrorT
 
  where
+  functionType [] [] arguments simpleType
+   = foldr TypeArrow simpleType arguments
+
   functionType foralls constraints arguments simpleType
-   = FunctionType
-   $ TypeForall foralls constraints
+   = TypeForall foralls constraints
    $ foldr TypeArrow simpleType arguments
 
   f0 argsT resT

--- a/icicle-source/src/Icicle/Source/Query/Prim.hs
+++ b/icicle-source/src/Icicle/Source/Query/Prim.hs
@@ -43,7 +43,7 @@ primLookup' prim
 
 
     Op (Relation _)
-     -> f1 $ \a at -> FunctionType [a] [] [at, at] BoolT
+     -> f1 $ \a at -> functionType [a] [] [at, at] BoolT
 
     Op (LogicalUnary _)
      -> f0 [BoolT] BoolT
@@ -57,7 +57,7 @@ primLookup' prim
            b <- Fresh.fresh
            let at = TypeVar a
            let bt = TypeVar b
-           return $ FunctionType [a,b] [] [at, bt] (PairT at bt)
+           return $ functionType [a,b] [] [at, bt] (PairT at bt)
 
     -- Literals will not be NaN or Inf
     Lit (LitInt _)
@@ -135,38 +135,38 @@ primLookup' prim
      -> f0 [TimeT] IntT
 
     Fun (BuiltinData Seq)
-     -> f2 $ \a at b bt -> FunctionType [a,b] [] [at,bt] bt
+     -> f2 $ \a at b bt -> functionType [a,b] [] [at,bt] bt
     Fun (BuiltinData Box)
-     -> f1 $ \a at -> FunctionType [a] [] [SumT ErrorT at] (Possibility PossibilityPossibly at)
+     -> f1 $ \a at -> functionType [a] [] [SumT ErrorT at] (Possibility PossibilityPossibly at)
 
     Fun (BuiltinArray ArraySort)
-     -> f1 $ \a at -> FunctionType [a] [] [ArrayT at] (ArrayT at)
+     -> f1 $ \a at -> functionType [a] [] [ArrayT at] (ArrayT at)
     Fun (BuiltinArray ArrayLength)
-     -> f1 $ \a at -> FunctionType [a] [] [ArrayT at] IntT
+     -> f1 $ \a at -> functionType [a] [] [ArrayT at] IntT
     Fun (BuiltinArray ArrayIndex)
-     -> f1 $ \a at -> FunctionType [a] [] [ArrayT at, IntT] (Possibility PossibilityPossibly at)
+     -> f1 $ \a at -> functionType [a] [] [ArrayT at, IntT] (Possibility PossibilityPossibly at)
 
     Fun (BuiltinMap MapKeys)
-     -> f2 $ \a at b bt -> FunctionType [a,b] [] [GroupT at bt] (ArrayT at)
+     -> f2 $ \a at b bt -> functionType [a,b] [] [GroupT at bt] (ArrayT at)
     Fun (BuiltinMap MapValues)
-     -> f2 $ \a at b bt -> FunctionType [a,b] [] [GroupT at bt] (ArrayT bt)
+     -> f2 $ \a at b bt -> functionType [a,b] [] [GroupT at bt] (ArrayT bt)
     Fun (BuiltinMap MapCreate)
-     -> f2 $ \k kt v vt -> FunctionType [k, v] [] [] (GroupT kt vt)
+     -> f2 $ \k kt v vt -> functionType [k, v] [] [] (GroupT kt vt)
     Fun (BuiltinMap MapInsert)
-     -> f2 $ \k kt v vt -> FunctionType [k, v] [] [kt, vt, GroupT kt vt] (Possibility PossibilityPossibly (GroupT kt vt))
+     -> f2 $ \k kt v vt -> functionType [k, v] [] [kt, vt, GroupT kt vt] (Possibility PossibilityPossibly (GroupT kt vt))
     Fun (BuiltinMap MapDelete)
-     -> f2 $ \k kt v vt -> FunctionType [k, v] [] [kt, GroupT kt vt] (GroupT kt vt)
+     -> f2 $ \k kt v vt -> functionType [k, v] [] [kt, GroupT kt vt] (GroupT kt vt)
     Fun (BuiltinMap MapLookup)
-     -> f2 $ \k kt v vt -> FunctionType [k, v] [] [kt, GroupT kt vt] (OptionT vt)
+     -> f2 $ \k kt v vt -> functionType [k, v] [] [kt, GroupT kt vt] (OptionT vt)
 
     PrimCon ConSome
-     -> f1 $ \a at -> FunctionType [a] [] [at] (OptionT at)
+     -> f1 $ \a at -> functionType [a] [] [at] (OptionT at)
 
     PrimCon ConNone
-     -> f1 $ \a at -> FunctionType [a] [] [] (OptionT at)
+     -> f1 $ \a at -> functionType [a] [] [] (OptionT at)
 
     PrimCon ConTuple
-     -> f2 $ \a at b bt -> FunctionType [a, b] [] [at, bt] (PairT at bt)
+     -> f2 $ \a at b bt -> functionType [a, b] [] [at, bt] (PairT at bt)
 
     PrimCon ConTrue
      -> f0 [] BoolT
@@ -174,17 +174,20 @@ primLookup' prim
      -> f0 [] BoolT
 
     PrimCon ConLeft
-     -> f2 $ \a at b bt -> FunctionType [a, b] [] [at] (SumT at bt)
+     -> f2 $ \a at b bt -> functionType [a, b] [] [at] (SumT at bt)
     PrimCon ConRight
-     -> f2 $ \a at b bt -> FunctionType [a, b] [] [bt] (SumT at bt)
+     -> f2 $ \a at b bt -> functionType [a, b] [] [bt] (SumT at bt)
 
     PrimCon (ConError _)
      -> f0 [] ErrorT
 
  where
+  functionType foralls constraints arguments simpleType
+   = FunctionType foralls constraints
+   $ foldr TypeArrow simpleType arguments
 
   f0 argsT resT
-   = return $ FunctionType [] [] argsT resT
+   = return $ functionType [] [] argsT resT
 
   -- A num operation that can introduce NaN or Inf and must be checked
   fNumPossibly f
@@ -196,10 +199,10 @@ primLookup' prim
   fNumDefinitely f
    = f1 $ \a at ->
      let (args,ret) = f at
-     in  FunctionType [a] [CIsNum at] args ret
+     in  functionType [a] [CIsNum at] args ret
 
   fNum f
-   = f2 (\a at p pt -> uncurry (FunctionType [a,p] [CPossibilityOfNum pt at]) (f pt at))
+   = f2 (\a at p pt -> uncurry (functionType [a,p] [CPossibilityOfNum pt at]) (f pt at))
 
   possiblyDouble = Possibility PossibilityPossibly DoubleT
 

--- a/icicle-source/src/Icicle/Source/ToCore/Context.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/Context.hs
@@ -29,7 +29,7 @@ import qualified        Data.Map as Map
 data Features a n k
  = Features
  { featuresConcretes :: Map InputId (FeatureConcrete a n k)
- , featuresFunctions :: Map   (Name n) (FunctionType n)
+ , featuresFunctions :: Map   (Name n) (Type n)
  , featureNow        :: Maybe (Name n)
  }
 

--- a/icicle-source/src/Icicle/Source/ToCore/Prim.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/Prim.hs
@@ -95,7 +95,7 @@ convertPrim p ann resT xts = go p
         return $ primmin $ Min.PrimConst $ Min.PrimConstLeft a' b'
    | otherwise
    = convertError
-   $ ConvertErrorPrimNoArguments ann 2 p
+   $ ConvertErrorPrimNoArguments ann 1 p
   go (PrimCon ConRight)
    | (_, _, SumT a b) <- decomposeT resT
    = do a' <- convertValType ann a
@@ -103,7 +103,7 @@ convertPrim p ann resT xts = go p
         return $ primmin $ Min.PrimConst $ Min.PrimConstRight a' b'
    | otherwise
    = convertError
-   $ ConvertErrorPrimNoArguments ann 2 p
+   $ ConvertErrorPrimNoArguments ann 1 p
   go (PrimCon (ConError err))
    = return $ CE.XValue () T.ErrorT $ V.VError err
 

--- a/icicle-source/src/Icicle/Source/Transform/ReifyPossibility.hs
+++ b/icicle-source/src/Icicle/Source/Transform/ReifyPossibility.hs
@@ -70,7 +70,7 @@ reifyPossibilityX' wrap x
        -> do arg'       <- reifyPossibilityX' wrap arg
              nValue     <- fresh
              nError     <- fresh
-             let a'  = wrapAnnot a
+             let a'      = wrapAnnot a
              let aValue  = definiteAnnot a
              let aError  = typeAnnot a' ErrorT
              let vValue  = Var  aValue nValue

--- a/icicle-source/src/Icicle/Source/Transform/SubstX.hs
+++ b/icicle-source/src/Icicle/Source/Transform/SubstX.hs
@@ -21,7 +21,7 @@ substX :: (Hashable n, Eq n)
        -> Exp a n
        -> Fresh n (Exp a n)
 substX ms x
- = reannotX fst
+ = reannot fst
  <$> substX' (fmap allvarsX ms) (allvarsX x)
 
 substQ :: (Hashable n, Eq n)
@@ -29,7 +29,7 @@ substQ :: (Hashable n, Eq n)
        -> Query a n
        -> Fresh n (Query a n)
 substQ ms q
- = reannotQ fst
+ = reannot fst
  <$> substQ' (fmap allvarsX ms) (allvarsQ q)
 
 --------------

--- a/icicle-source/src/Icicle/Source/Type/Base.hs
+++ b/icicle-source/src/Icicle/Source/Type/Base.hs
@@ -179,9 +179,8 @@ instance Pretty n => Pretty (Type n) where
       annotate AnnVariable (pretty v)
     TypeForall _ cs x ->
       pretty $ PrettyFunType (fmap pretty cs) [] (pretty x)
-    TypeArrow f a ->
-      pretty f <+> text "->" <+> pretty a
-
+    TypeArrow f x ->
+      pretty $ PrettyFunType [] [pretty f] (pretty x)
     Temporality a b ->
       prettyApp hsep p a [b]
     TemporalityPure ->

--- a/icicle-source/src/Icicle/Source/Type/Base.hs
+++ b/icicle-source/src/Icicle/Source/Type/Base.hs
@@ -56,6 +56,8 @@ data Type n
  | PossibilityDefinitely
 
  | TypeVar             (Name n)
+--  | TypeForall          (Name n) (Type n)
+ | TypeArrow           (Type n) (Type n)
  deriving (Eq, Ord, Show, Generic)
 
 instance NFData n => NFData (Type n)
@@ -109,6 +111,8 @@ valTypeOfType bt
     PossibilityDefinitely   -> Nothing
 
     TypeVar _               -> Nothing
+    -- TypeForall _ _          -> Nothing
+    TypeArrow _ _           -> Nothing
  where
   go = valTypeOfType
 
@@ -130,7 +134,7 @@ data FunctionType n
  = FunctionType
  { functionForalls      :: [Name n]
  , functionConstraints  :: [Constraint n]
- , functionArguments    :: [Type n]
+--  , functionArguments    :: [Type n]
  , functionReturn       :: Type n
  }
  deriving (Eq, Ord, Show, Generic)
@@ -185,6 +189,10 @@ instance Pretty n => Pretty (Type n) where
       prettyStructType hcat . fmap (bimap pretty pretty) $ Map.toList fs
     TypeVar v ->
       annotate AnnVariable (pretty v)
+    -- TypeForall _ b ->
+    --   pretty b
+    TypeArrow f a ->
+      annotate AnnVariable (pretty f) <+> text "->" <+> annotate AnnVariable (pretty a)
 
     Temporality a b ->
       prettyApp hsep p a [b]
@@ -239,7 +247,7 @@ prettyFun :: Pretty n => FunctionType n -> PrettyFunType
 prettyFun fun =
   PrettyFunType
     (fmap pretty $ functionConstraints fun)
-    (fmap pretty $ functionArguments fun)
+    []
     (pretty $ functionReturn fun)
 
 instance Pretty n => Pretty (FunctionType n) where

--- a/icicle-source/src/Icicle/Source/Type/Base.hs
+++ b/icicle-source/src/Icicle/Source/Type/Base.hs
@@ -13,10 +13,8 @@ module Icicle.Source.Type.Base (
   , typeOfValType
   , valTypeOfType
   , Constraint  (..)
-  , FunctionType(..)
   , Annot (..)
   , annotDiscardConstraints
-  , prettyFun
   ) where
 
 import qualified Data.Map as Map
@@ -131,17 +129,6 @@ data Constraint n
 
 instance NFData n => NFData (Constraint n)
 
-data FunctionType n
- = FunctionType
- { --   functionForalls      :: [Name n]
-   --   functionConstraints  :: [Constraint n]
-   --  , functionArguments    :: [Type n]
-  functionReturn       :: Type n
- }
- deriving (Eq, Ord, Show, Generic)
-
-instance NFData n => NFData (FunctionType n)
-
 data Annot a n
  = Annot
  { annAnnot         :: a
@@ -190,10 +177,10 @@ instance Pretty n => Pretty (Type n) where
       prettyStructType hcat . fmap (bimap pretty pretty) $ Map.toList fs
     TypeVar v ->
       annotate AnnVariable (pretty v)
-    TypeForall ns cs x ->
-      pretty $ PrettyFunType (fmap pretty cs) (fmap pretty ns) (pretty x)
+    TypeForall _ cs x ->
+      pretty $ PrettyFunType (fmap pretty cs) [] (pretty x)
     TypeArrow f a ->
-      annotate AnnVariable (pretty f) <+> text "->" <+> annotate AnnVariable (pretty a)
+      pretty f <+> text "->" <+> pretty a
 
     Temporality a b ->
       prettyApp hsep p a [b]
@@ -243,16 +230,6 @@ instance Pretty n => Pretty (Constraint n) where
     CPossibilityJoin a b c ->
       pretty a <+> prettyPunctuation "=:" <+>
       prettyApp hsep 0 (prettyConstructor "PossibilityJoin") [b, c]
-
-prettyFun :: Pretty n => FunctionType n -> PrettyFunType
-prettyFun (FunctionType (TypeForall ns cs x)) =
-  PrettyFunType (fmap pretty cs) (fmap pretty ns) (pretty x)
-prettyFun (FunctionType x) =
-  PrettyFunType [] [] (pretty x)
-
-instance Pretty n => Pretty (FunctionType n) where
-  pretty =
-    pretty . functionReturn
 
 instance (Pretty n) => Pretty (Annot a n) where
   pretty ann =

--- a/icicle-source/src/Icicle/Source/Type/Compounds.hs
+++ b/icicle-source/src/Icicle/Source/Type/Compounds.hs
@@ -31,7 +31,7 @@ import                  Data.Hashable (Hashable)
 
 function0 :: Type n -> FunctionType n
 function0 u
- = FunctionType [] [] u
+ = FunctionType u
 
 freeT :: (Hashable n, Eq n) => Type n -> Set.Set (Name n)
 freeT t
@@ -63,7 +63,7 @@ freeT t
     PossibilityDefinitely   -> Set.empty
 
     TypeVar n               -> Set.singleton n
-    -- TypeForall a b          -> Set.delete a (freeT b)
+    TypeForall ns cs b      -> Set.difference (Set.union (Set.unions (fmap freeC cs)) (freeT b)) (Set.fromList ns)
     TypeArrow f b           -> Set.union (freeT f) (freeT b)
 
 
@@ -147,8 +147,8 @@ getTemporality tt
     PossibilityDefinitely -> Nothing
 
     TypeVar _             -> Nothing
-    -- TypeForall a b        -> wrap go (TypeForall a) b
-    TypeArrow f a         -> Nothing -- wrap2 go TypeArrow f a
+    TypeForall _ _ _      -> Nothing
+    TypeArrow _ _         -> Nothing -- wrap2 go TypeArrow f a
 
  where
   go = getTemporality
@@ -195,8 +195,8 @@ getPossibility tt
     PossibilityDefinitely -> Nothing
 
     TypeVar _             -> Nothing
-    -- TypeForall a b        -> wrap go (TypeForall a) b
-    TypeArrow f a         -> Nothing -- wrap2 go TypeArrow f a
+    TypeForall _ _ _      -> Nothing
+    TypeArrow _ _         -> Nothing -- wrap2 go TypeArrow f a
 
  where
   go = getPossibility
@@ -234,7 +234,7 @@ getBaseType tt
     PossibilityDefinitely -> Nothing
 
     TypeVar _             -> Just tt
-    -- TypeForall _ _        -> Just tt
+    TypeForall _ _ _      -> Just tt
     TypeArrow _ _         -> Just tt
 
 -- Temporality and possibility helpers --

--- a/icicle-source/src/Icicle/Source/Type/Compounds.hs
+++ b/icicle-source/src/Icicle/Source/Type/Compounds.hs
@@ -14,6 +14,8 @@ module Icicle.Source.Type.Compounds (
   , getPossibility
   , getTemporalityOrPure
   , getPossibilityOrDefinitely
+
+  , anyArrows
   ) where
 
 
@@ -24,6 +26,7 @@ import                  P
 
 import                  Data.List (zipWith, zip)
 import qualified        Data.Map as Map
+import                  Data.Monoid (Any (..))
 import qualified        Data.Set as Set
 import                  Data.Hashable (Hashable)
 
@@ -259,3 +262,9 @@ wrapN go f ts
        Nothing -> Nothing
        Just tmp' -> f tmp' args
 
+
+anyArrows :: Type n -> Bool
+anyArrows
+ = let go (TypeArrow {}) = Any True
+       go x = foldTypePlate go x
+   in getAny . go

--- a/icicle-source/src/Icicle/Source/Type/Compounds.hs
+++ b/icicle-source/src/Icicle/Source/Type/Compounds.hs
@@ -4,8 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 module Icicle.Source.Type.Compounds (
-    function0
-  , freeT
+    freeT
   , freeC
   , canonT
   , decomposeT
@@ -28,10 +27,6 @@ import qualified        Data.Map as Map
 import qualified        Data.Set as Set
 import                  Data.Hashable (Hashable)
 
-
-function0 :: Type n -> FunctionType n
-function0 u
- = FunctionType u
 
 freeT :: (Hashable n, Eq n) => Type n -> Set.Set (Name n)
 freeT t

--- a/icicle-source/src/Icicle/Source/Type/Compounds.hs
+++ b/icicle-source/src/Icicle/Source/Type/Compounds.hs
@@ -266,5 +266,5 @@ wrapN go f ts
 anyArrows :: Type n -> Bool
 anyArrows
  = let go (TypeArrow {}) = Any True
-       go x = foldTypePlate go x
+       go x = foldSourceType go x
    in getAny . go

--- a/icicle-source/src/Icicle/Source/Type/Compounds.hs
+++ b/icicle-source/src/Icicle/Source/Type/Compounds.hs
@@ -31,7 +31,7 @@ import                  Data.Hashable (Hashable)
 
 function0 :: Type n -> FunctionType n
 function0 u
- = FunctionType [] [] [] u
+ = FunctionType [] [] u
 
 freeT :: (Hashable n, Eq n) => Type n -> Set.Set (Name n)
 freeT t
@@ -63,6 +63,8 @@ freeT t
     PossibilityDefinitely   -> Set.empty
 
     TypeVar n               -> Set.singleton n
+    -- TypeForall a b          -> Set.delete a (freeT b)
+    TypeArrow f b           -> Set.union (freeT f) (freeT b)
 
 
 freeC :: (Hashable n, Eq n) => Constraint n -> Set.Set (Name n)
@@ -145,6 +147,8 @@ getTemporality tt
     PossibilityDefinitely -> Nothing
 
     TypeVar _             -> Nothing
+    -- TypeForall a b        -> wrap go (TypeForall a) b
+    TypeArrow f a         -> Nothing -- wrap2 go TypeArrow f a
 
  where
   go = getTemporality
@@ -191,6 +195,8 @@ getPossibility tt
     PossibilityDefinitely -> Nothing
 
     TypeVar _             -> Nothing
+    -- TypeForall a b        -> wrap go (TypeForall a) b
+    TypeArrow f a         -> Nothing -- wrap2 go TypeArrow f a
 
  where
   go = getPossibility
@@ -228,7 +234,8 @@ getBaseType tt
     PossibilityDefinitely -> Nothing
 
     TypeVar _             -> Just tt
-
+    -- TypeForall _ _        -> Just tt
+    TypeArrow _ _         -> Just tt
 
 -- Temporality and possibility helpers --
 

--- a/icicle-source/src/Icicle/Source/Type/Constraints.hs
+++ b/icicle-source/src/Icicle/Source/Type/Constraints.hs
@@ -1,9 +1,10 @@
 -- | Doing things with Constraints
 --
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternGuards     #-}
+{-# LANGUAGE LambdaCase        #-}
 module Icicle.Source.Type.Constraints (
     DischargeResult (..)
   , DischargeError (..)

--- a/icicle-source/src/Icicle/Source/Type/Pretty.hs
+++ b/icicle-source/src/Icicle/Source/Type/Pretty.hs
@@ -5,8 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 module Icicle.Source.Type.Pretty (
-    prettyFun
-  , prettyFunWithNames
+    prettyFunWithNames
   , prettyFunWithLetters
   , prettyFunFromStrings
   , letterNames
@@ -23,29 +22,52 @@ import                  Icicle.Internal.Pretty
 import                  P
 
 import                  Data.String
-import                  Data.List (zip)
+import                  Data.List (splitAt, zip)
 import qualified        Data.Map as Map
 import qualified        Data.Text as T
 import                  Data.Hashable (Hashable)
 
 
 -- | This is a rather dodgy trick.
--- Function types are generalised with fresh variable names,
--- however fresh variable names are quite ugly.
--- Instead of actually using nice names, we will clean them up
--- just before pretty printing.
-prettyFunWithNames :: (Pretty n, Eq n) => [Name n] -> FunctionType n -> PrettyFunType
-prettyFunWithNames names fun
-  =  prettyFun fun
+--   Function types are generalised with fresh variable names,
+--   however fresh variable names are quite ugly.
+--   Instead of actually using nice names, we will clean them up
+--   just before pretty printing.
+prettyFunWithNames :: (Pretty n, Eq n) => [Name n] -> Type n -> PrettyFunType
+prettyFunWithNames names typ
+ = case typ of
+    TypeArrow f typ0 ->
+      let
+        PrettyFunType consX argsX typ1 =
+          prettyFunWithNames names typ0
+      in
+        PrettyFunType consX (pretty f : argsX) (pretty typ1)
+
+    TypeForall ns cons0 typ0 ->
+      let
+        (names0, namesRest) =
+          splitAt (length ns) names
+        sub =
+          Map.fromList (ns `zip` fmap TypeVar names0)
+        cons1 =
+          fmap (substC sub) cons0
+        typ1 =
+          substT sub typ0
+        PrettyFunType consX argsX typ2 =
+          prettyFunWithNames namesRest typ1
+      in
+        PrettyFunType (fmap pretty cons1 <> consX) argsX (pretty typ2)
+    x ->
+      PrettyFunType [] [] (pretty x)
 
 -- We make them actual names (with the hash code) because they will be used
 -- for substituations.
-prettyFunFromStrings :: (IsString n, Pretty n, Hashable n, Eq n) => FunctionType n -> PrettyFunType
+prettyFunFromStrings :: (IsString n, Pretty n, Hashable n, Eq n) => Type n -> PrettyFunType
 prettyFunFromStrings
  = prettyFunWithNames
  $ fmap (nameOf . NameBase . fromString) letterNames
 
-prettyFunWithLetters :: FunctionType Variable -> PrettyFunType
+prettyFunWithLetters :: Type Variable -> PrettyFunType
 prettyFunWithLetters
  = prettyFunWithNames
  $ fmap (nameOf . NameBase . Variable . T.pack) letterNames

--- a/icicle-source/src/Icicle/Source/Type/Pretty.hs
+++ b/icicle-source/src/Icicle/Source/Type/Pretty.hs
@@ -36,13 +36,7 @@ import                  Data.Hashable (Hashable)
 -- just before pretty printing.
 prettyFunWithNames :: (Pretty n, Eq n) => [Name n] -> FunctionType n -> PrettyFunType
 prettyFunWithNames names fun
-  =  prettyFun fun'
-  where
-   sub
-    = Map.fromList
-    (functionForalls fun `zip` fmap TypeVar names)
-
-   fun' = substFT sub (fun { functionForalls = [] })
+  =  prettyFun fun
 
 -- We make them actual names (with the hash code) because they will be used
 -- for substituations.

--- a/icicle-source/src/Icicle/Source/Type/Subst.hs
+++ b/icicle-source/src/Icicle/Source/Type/Subst.hs
@@ -3,7 +3,9 @@
 --
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternGuards     #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE TupleSections     #-}
 module Icicle.Source.Type.Subst (
     SubstT
   , substT
@@ -14,10 +16,13 @@ module Icicle.Source.Type.Subst (
 
 
 import                  Icicle.Common.Base
+
 import                  Icicle.Source.Type.Base
 import                  Icicle.Source.Type.Compounds
 
 import                  P
+
+import                  Control.Lens (over)
 
 import qualified        Data.Map as Map
 import qualified        Data.Set as Set
@@ -25,77 +30,27 @@ import                  Data.Hashable (Hashable)
 
 type SubstT n = Map.Map (Name n) (Type n)
 
+
+--- | Substitute into a type.
 substT :: Eq n => SubstT n -> Type n -> Type n
-substT ss tt
- = canonT
- $ go tt
+substT ss
+ = canonT . go ss
  where
-
-  go t
-   = case t of
-      BoolT         -> t
-      TimeT         -> t
-      DoubleT       -> t
-      IntT          -> t
-      StringT       -> t
-      UnitT         -> t
-      ErrorT        -> t
-
-      ArrayT  a     -> ArrayT  (go a)
-      GroupT  a b   -> GroupT  (go a) (go b)
-      OptionT a     -> OptionT (go a)
-      PairT   a b   -> PairT   (go a) (go b)
-      SumT    a b   -> SumT    (go a) (go b)
-      StructT fs    -> StructT (Map.map go fs)
-
-      Temporality a b       -> Temporality (go a) (go b)
-      TemporalityPure       -> t
-      TemporalityElement    -> t
-      TemporalityAggregate  -> t
-
-      Possibility a b       -> Possibility (go a) (go b)
-      PossibilityPossibly   -> t
-      PossibilityDefinitely -> t
-
-      TypeVar n
-       | Just t' <- Map.lookup n ss
-       -> t'
-       | otherwise
-       -> t
-
-      --- | Substitute into a forall type.
-      --- It is very important that any binders in here are unique.
-      --- If the binders mention any names in the substitution, things WILL go awry.
-      --- This is not a problem for type checking since all names are fresh.
-      ---
-      --- Because the function constraints will only mention newly bound type variables,
-      --- it is not necessary to substitute into the constraints.
-      ---
-      --- Perhaps this should actually be called "unsafeSubstT" because none of these
-      --- invariants are checked.
-      TypeForall ns c b     -> TypeForall  ns     (fmap (substC ss) c) (go b)
-      TypeArrow a b         -> TypeArrow   (go a) (go b)
-
+  go ss0 = \case
+    TypeVar n
+      | Just t' <- Map.lookup n ss
+      -> t'
+    TypeForall ns cs r
+      -> let ss1  = ss Map.\\ Map.fromList ((,()) <$> ns)
+             cs1  = fmap (substC ss1) cs
+             r1   = go ss1 r
+         in  TypeForall ns cs1 r1
+    t
+      -> mapSourceType (go ss0) t
 
 substC :: Eq n => SubstT n -> Constraint n -> Constraint n
-substC ss cc
- = case cc of
-    CEquals p q
-     -> CEquals (substT ss p) (substT ss q)
-    CIsNum t
-     -> CIsNum (substT ss t)
-    CPossibilityOfNum p t
-     -> CPossibilityOfNum (substT ss p) (substT ss t)
-    CTemporalityJoin a b c
-     -> CTemporalityJoin (substT ss a) (substT ss b) (substT ss c)
-    CReturnOfLetTemporalities ret def body
-     -> CReturnOfLetTemporalities (substT ss ret) (substT ss def) (substT ss body)
-    CDataOfLatest ret tmp pos dat
-     -> CDataOfLatest (substT ss ret) (substT ss tmp) (substT ss pos) (substT ss dat)
-    CPossibilityOfLatest ret tmp pos
-     -> CPossibilityOfLatest (substT ss ret) (substT ss tmp) (substT ss pos)
-    CPossibilityJoin ret b c
-     -> CPossibilityJoin (substT ss ret) (substT ss b) (substT ss c)
+substC ss
+ = over traverseType (substT ss)
 
 
 -- | Compose two substitutions together, in order.
@@ -227,9 +182,10 @@ unifyT t1 t2
     PossibilityPossibly     -> eq
     PossibilityDefinitely   -> eq
 
-    TypeForall n _ac at
-     | TypeForall m _bc bt <- t2
+    TypeForall n ac at
+     | TypeForall m bc bt <- t2
      , n == m
+     , ac == bc
      -> unifyT at bt
      | otherwise
      -> Nothing


### PR DESCRIPTION
@amosr  do you think you could have a look at this?

In Sorbet, the alternative syntax, things like lambda case and first class functions make an appearance, and it seems like a worthwhile exercise to support these (as long as they don't permit recursion and other things which would break the runtime semantics).

This piece of work doesn't change the language as far as I can see, but it removes the special `FunctionType` type we have for functions, by adding `TypeArrow` and `TypeForall` to the source type system.

I have an almost working follow on with `Lam` expressions, but I think this should be put in I go further.