### PR TITLE
Improve PSV query output support

### DIFF
--- a/icicle-compiler/main/icicle.hs
+++ b/icicle-compiler/main/icicle.hs
@@ -91,13 +91,15 @@ pReplZebra :: Parser FilePath
 pReplZebra =
   Options.argument Options.str $
     Options.metavar "INPUT_ZEBRA" <>
-    Options.help "Path to a Zebra binary file to load"
+    Options.help "Path to a Zebra binary file to load" <>
+    Options.action "file"
 
 pReplPSV :: Parser FilePath
 pReplPSV =
   Options.argument Options.str $
     Options.metavar "INPUT_PSV" <>
-    Options.help "Path to a PSV file to load"
+    Options.help "Path to a PSV file to load" <>
+    Options.action "file"
 
 pReplTOML :: Parser FilePath
 pReplTOML =
@@ -155,7 +157,8 @@ pInputDictionaryIcicle =
   Options.option Options.str $
     Options.long "input-icicle" <>
     Options.metavar "DICTIONARY_ICICLE" <>
-    Options.help "Path to a ICICLE dictionary to compile."
+    Options.help "Path to a ICICLE dictionary to compile." <>
+    Options.action "file"
 
 pOutputDictionarySea :: Parser OutputDictionarySea
 pOutputDictionarySea =
@@ -163,7 +166,8 @@ pOutputDictionarySea =
   Options.option Options.str $
     Options.long "output-c" <>
     Options.metavar "DICTIONARY_C" <>
-    Options.help "Path to write the compiled C dictionary."
+    Options.help "Path to write the compiled C dictionary." <>
+    Options.action "file"
 
 pQuery :: Parser Query
 pQuery =
@@ -192,7 +196,8 @@ pInputZebra =
   Options.option Options.str $
     Options.long "input-zebra" <>
     Options.metavar "INPUT_ZEBRA" <>
-    Options.help "Path to a zebra binary file."
+    Options.help "Path to a zebra binary file." <>
+    Options.action "file"
 
 pQueryOutput :: Parser QueryOutput
 pQueryOutput =
@@ -205,7 +210,8 @@ pOutputZebra =
   Options.option Options.str $
     Options.long "output-zebra" <>
     Options.metavar "OUTPUT_ZEBRA" <>
-    Options.help "Path to write the zebra binary output file."
+    Options.help "Path to write the zebra binary output file." <>
+    Options.action "file"
 
 pOutputPsv :: Parser OutputPsv
 pOutputPsv =
@@ -213,7 +219,8 @@ pOutputPsv =
   Options.option Options.str $
     Options.long "output-psv" <>
     Options.metavar "OUTPUT_PSV" <>
-    Options.help "Path to write the dense psv file."
+    Options.help "Path to write the dense psv file." <>
+    Options.action "file"
 
 pOutputPsvSchema :: Parser OutputPsvSchema
 pOutputPsvSchema =
@@ -221,7 +228,8 @@ pOutputPsvSchema =
   Options.option Options.str $
     Options.long "output-psv-schema" <>
     Options.metavar "OUTPUT_PSV_SCHEMA_JSON" <>
-    Options.help "Location to write the output schema for a dense psv output. (default: <output-path>.schema.json)"
+    Options.help "Location to write the output schema for a dense psv output. (default: <output-path>.schema.json)" <>
+    Options.action "file"
 
 pQuerySnapshot :: Parser QueryScope
 pQuerySnapshot =

--- a/icicle-compiler/src/Icicle/Runtime/Data/Schema.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Data/Schema.hs
@@ -23,7 +23,7 @@ import qualified Data.Vector as Boxed
 
 import           GHC.Generics (Generic)
 
-import           Icicle.Common.Type
+import           Icicle.Common.Type as CT
 import qualified Icicle.Data.Fact as Fact
 import           Icicle.Runtime.Data.Primitive
 

--- a/icicle-compiler/src/Icicle/Runtime/Serial/Psv/Data.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Serial/Psv/Data.hs
@@ -211,15 +211,14 @@ encodeColumn column =
       pure $
         Boxed.zipWith (encodeMissing "NA" NotAnError64) (Storable.convert tags) values
 
-    Striped.Pair _ _ ->
-      Left $
-        SerialPsvDataUnsupportedSchema (Striped.schema column)
-
     Striped.String ns bs ->
       bimap
         (SerialPsvDataSegmentError Schema.String)
         (fmap encodeQuotedString) $
         Segment.reify ns bs
+
+    Striped.Pair {} ->
+      encodeAsJson column
 
     Striped.Struct {} ->
       encodeAsJson column

--- a/icicle-compiler/src/Icicle/Runtime/Serial/Psv/Schema.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Serial/Psv/Schema.hs
@@ -43,10 +43,12 @@ import qualified Data.Map.Strict as Map
 import           Data.String (String)
 import qualified Data.Text as Text
 import qualified Data.Vector as Boxed
+import qualified X.Data.Vector.Cons as Cons
 
 import           Icicle.Data.Name
 import           Icicle.Internal.Aeson
 import qualified Icicle.Runtime.Data.Schema as Icicle
+import qualified Icicle.Runtime.Data.Primitive as Icicle
 
 import           P
 
@@ -340,10 +342,9 @@ encodePsvEncoding schema =
       Left $
         SerialPsvUnsupportedSchema schema
 
-    Icicle.Struct _ ->
-      -- FIXME
-      Left $
-        SerialPsvUnsupportedSchema schema
+    Icicle.Struct fields ->
+      PsvStruct <$>
+        traverse (\(Icicle.Field n e) -> PsvStructField n <$> encodePsvEncoding e) (Cons.toList fields)
 
     Icicle.String ->
       pure $ PsvPrimitive PsvString

--- a/icicle-compiler/src/Icicle/Runtime/Serial/Psv/Schema.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Serial/Psv/Schema.hs
@@ -338,9 +338,8 @@ encodePsvEncoding schema =
     Icicle.Result x ->
       encodePsvEncoding x
 
-    Icicle.Pair _ _ ->
-      Left $
-        SerialPsvUnsupportedSchema schema
+    Icicle.Pair a b ->
+      PsvPair <$> encodePsvEncoding a <*> encodePsvEncoding b
 
     Icicle.Struct fields ->
       PsvStruct <$>


### PR DESCRIPTION
Providing adequate support here is important to lower
the barrier to entry.

- Support struct type output in PSV mode
- Quote psv output strings which include delimiters
- Support pair outputs in PSV
