### PR TITLE
Improve annotations for applications in source language.

### DIFF
--- a/icicle-compiler/src/Icicle/LSP/Task/Hover.hs
+++ b/icicle-compiler/src/Icicle/LSP/Task/Hover.hs
@@ -13,7 +13,7 @@ import qualified Data.Map  as Map
 import qualified Data.Text as Text
 import           Data.Aeson as Aeson
 
-import           Data.Monoid (getFirst)
+import           Data.Monoid (getLast)
 
 import           Icicle.LSP.State
 import           Icicle.LSP.Interface
@@ -69,7 +69,7 @@ typeAt pos module_ = do
     exprs1 = traverseAnnot (findRange pos) `traverse` (functionDefinition <$> resolvedEntries module_)
     ranged = void exprs0 <> void exprs1 <> void exprs2
 
-  getFirst $
+  getLast $
     getConst ranged
 
 

--- a/icicle-source/src/Icicle/Source/ToCore/Base.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/Base.hs
@@ -152,6 +152,7 @@ data ConvertError a n
  | ConvertErrorExpApplicationOfNonPrimitive  a (Exp (Annot a n) n)
  | ConvertErrorReduceAggregateBadArguments   a (Exp (Annot a n) n)
  | ConvertErrorCannotConvertType             a (Type n)
+ | ConvertErrorCannotConvertTypeForPrim      a Prim (Type n)
  | ConvertErrorBadCaseNoDefault              a ValType (Exp (Annot a n) n)
  | ConvertErrorBadCaseNestedConstructors     a (Exp (Annot a n) n)
  | ConvertErrorImpossibleFold1               a
@@ -188,6 +189,8 @@ annotOfError e
     ConvertErrorReduceAggregateBadArguments a _
      -> Just a
     ConvertErrorCannotConvertType a _
+     -> Just a
+    ConvertErrorCannotConvertTypeForPrim a _ _
      -> Just a
     ConvertErrorBadCaseNoDefault a _ _
      -> Just a
@@ -391,6 +394,9 @@ instance (Pretty a, Pretty n) => Pretty (ConvertError a n) where
 
      ConvertErrorCannotConvertType a t
       -> pretty a <> ": cannot convert base type: " <> pretty t
+
+     ConvertErrorCannotConvertTypeForPrim a p t
+      -> pretty a <> ": cannot convert prim: " <> pretty p <> "; unexpected type type: " <> pretty t
 
      ConvertErrorBadCaseNoDefault a t x
       -> pretty a <> ": case has no default alternative, type " <> pretty t <> line  <> pretty x

--- a/icicle-source/src/Icicle/Source/ToCore/Exp.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/Exp.hs
@@ -66,7 +66,6 @@ convertExp x
     Nested _ q
      -> convertExpQ q
 
-
     App ann f q
      -- Primitive application: convert arguments, then convert primitive
      | Just (p, Annot { annResult = resT }, args) <- takePrimApps x
@@ -377,7 +376,7 @@ unwrapSum
     -> C.Exp () n
     -> C.Exp () n
 unwrapSum isPossibly rett nErr x nk t bodyx
- | T.SumT T.ErrorT ty <- t
+ | T.SumT T.ErrorT ty   <- t
  , T.SumT T.ErrorT ret' <- rett
  -- We can only do this for (Sum Error)s introduced by Reify:
  -- not ones that the programmer explicitly wrote

--- a/icicle-source/src/Icicle/Source/Type/Pretty.hs
+++ b/icicle-source/src/Icicle/Source/Type/Pretty.hs
@@ -51,4 +51,3 @@ letterNames :: [String]
 letterNames
  =  fmap (\c -> [c]) ['a'..'z']
  <> concatMap (\prefix -> fmap (\c -> prefix <> [c]) ['a'..'z']) letterNames
- 


### PR DESCRIPTION
Previously, the annotations with App constructors were a bit of
a lie, as the left hand side was always the same as the outer
application.

This meant that our types shown in the language server when
hovering were incorrect, and was just a bit unfortunate, as the
true types for functions were lost.

Fortunately, this is mostly a simplification, as App nodes no
longer need to do lookups for type schemes, and can focus on
just themselves. To maintain our "no closures" invariant, we
can lift our anyArrows check to a simple, non-traversing one.

Some work was required on the Reification phase and ToCore phase,
as they made assumed the previous behaviour.

Also remove a bunch of redundant checks in convertReduce, which
were looking for pure expressions to bind as precomputations; all
of these were already handled in the very first pattern.
