### PR TITLE
Optimise array operations by reducing redundant copies

### DIFF
--- a/data/sea/30-array.h
+++ b/data/sea/30-array.h
@@ -247,7 +247,7 @@ static ARRAY_T(t) INLINE ARRAY_FUN(t,swap)                                      
 
 
 /*
-Immutable Delete (arr, ix)
+Mutable Delete (arr, ix)
 */
 
 #define MK_ARRAY_DELETE(t)                                                      \
@@ -258,25 +258,17 @@ static ARRAY_T(t) INLINE ARRAY_FUN(t,delete)                                    
     VALID_ARRAY(x)                                                              \
     VALID_INDEX(ix_delete, x)                                                   \
                                                                                 \
-    iint_t count      = x->count;                                               \
-    iint_t capacity   = iarray_size(count - 1);                                 \
-    size_t bytes      = ARRAY_SIZE(t, capacity);                                \
+    iint_t count = x->count;                                                    \
                                                                                 \
-    ARRAY_T(t) arr = (ARRAY_T(t))anemone_mempool_alloc(pool, bytes);            \
-                                                                                \
-    for (iint_t ix = 0; ix != ix_delete; ++ix) {                                \
-        t##_t val = ARRAY_PAYLOAD(t,x)[ix];                                     \
-        ARRAY_PAYLOAD(t,arr)[ix] = val;                                         \
-    }                                                                           \
     for (iint_t ix = ix_delete + 1; ix != count; ++ix) {                        \
         t##_t val = ARRAY_PAYLOAD(t,x)[ix];                                     \
-        ARRAY_PAYLOAD(t,arr)[ix - 1] = val;                                     \
+        ARRAY_PAYLOAD(t,x)[ix - 1] = val;                                       \
     }                                                                           \
                                                                                 \
-    arr->count = count - 1;                                                     \
+    x->count = count - 1;                                                       \
                                                                                 \
-    VALID_ARRAY(arr)                                                            \
-    return arr;                                                                 \
+    VALID_ARRAY(x)                                                              \
+    return x;                                                                   \
 }
 
 

--- a/icicle-compiler/icicle.cabal
+++ b/icicle-compiler/icicle.cabal
@@ -68,6 +68,7 @@ library
                      , semigroups                      >= 0.16       && < 0.19
                      , streaming-attoparsec
                      , stm
+                     , tardis
                      , template-haskell                >= 2.7        && < 2.21
                      , temporary                       == 1.2.*
                      , terminal-size                   == 0.3.*
@@ -108,6 +109,7 @@ library
                        Icicle.Avalanche.Statement.Simp.Eval
                        Icicle.Avalanche.Statement.Simp.ExpEnv
                        Icicle.Avalanche.Statement.Simp.Freshen
+                       Icicle.Avalanche.Statement.Simp.Linear
                        Icicle.Avalanche.Statement.Simp.Melt
                        Icicle.Avalanche.Statement.Simp.ThreshOrd
                        Icicle.Avalanche.Statement.Flatten
@@ -270,6 +272,7 @@ test-suite test
                      , exceptions
                      , filepath
                      , geniplate-mirror                >= 0.7.2      && < 0.8
+                     , lens
                      , megaparsec
                      , mtl
                      , pretty-show
@@ -308,6 +311,7 @@ test-suite test
                        Icicle.Test.Avalanche.Flatten
                        Icicle.Test.Avalanche.Melt
                        Icicle.Test.Avalanche.MeltPrim
+                       Icicle.Test.Avalanche.Simp.Linear
                        Icicle.Test.Avalanche.SimpCommutes
                        Icicle.Test.Common.Data
                        Icicle.Test.Core.Exp.Alpha

--- a/icicle-compiler/src/Icicle/Avalanche/Prim/Compounds.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Prim/Compounds.hs
@@ -31,6 +31,7 @@ data FlatOps a n = FlatOps {
   , arrDel  :: ValType -> X a n -> X a n -> X a n
   , arrZip  :: ValType -> ValType
             -> X a n -> X a n -> X a n
+  , arrCpy  :: ValType -> X a n -> X a n
 
   , mapPack :: ValType -> ValType -> X a n -> X a n -> X a n
   , mapKeys :: ValType -> ValType -> X a n -> X a n
@@ -78,7 +79,8 @@ flatOps a_fresh
   arrIx   t     = p2 (PrimUnsafe  $ PrimUnsafeArrayIndex   t)
   arrNew  t     = p1 (PrimUnsafe  $ PrimUnsafeArrayCreate  t)
   arrUpd  t     = p3 (PrimArray   $ PrimArrayPutImmutable  t)
-  arrUpd' t     = p3 (PrimArray   $ PrimArrayPutMutable  t)
+  arrUpd' t     = p3 (PrimArray   $ PrimArrayPutMutable    t)
+  arrCpy  t     = p1 (PrimArray   $ PrimArrayCopy          t)
   arrDel  t     = p2 (PrimArray   $ PrimArrayDel           t)
   arrZip  k v   = p2 (PrimArray   $ PrimArrayZip           k v)
 

--- a/icicle-compiler/src/Icicle/Avalanche/Prim/Eval.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Prim/Eval.hs
@@ -178,6 +178,11 @@ evalPrim p vs
       | otherwise
       -> primError
 
+     PrimArray (PrimArrayCopy _)
+      | [VBase (VArray arr)]  <- vs
+      -> return $ VBase $ VArray arr
+      | otherwise
+      -> primError
 
      -- XXX: is this returning values even if primitive is under applied?
      PrimMelt (PrimMeltPack t)

--- a/icicle-compiler/src/Icicle/Avalanche/Prim/Flat.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Prim/Flat.hs
@@ -90,6 +90,7 @@ data PrimArray
  | PrimArrayZip          !ValType !ValType -- ^ Zip two arrays into one
  | PrimArraySwap         !ValType          -- ^ Swap two elements
  | PrimArrayDel          !ValType          -- ^ Delete a value
+ | PrimArrayCopy         !ValType          -- ^ Delete a value
  deriving (Eq, Ord, Show, Generic)
 
 data PrimMap
@@ -170,6 +171,8 @@ typeOfPrim p
     PrimArray   (PrimArrayDel a)
      -> FunT [funOfVal (ArrayT a), funOfVal IntT] (ArrayT a)
 
+    PrimArray   (PrimArrayCopy a)
+     -> FunT [funOfVal (ArrayT a)] (ArrayT a)
 
     PrimMelt    (PrimMeltPack t)
      | ts <- meltType t
@@ -199,10 +202,11 @@ typeOfPrim p
     PrimBuf     (PrimBufRead i t)
      -> FunT [funOfVal (BufT i t)] (ArrayT t)
 
+
 -- We need to distinguish between an error and an error which is the tag in (Sum Error t)
 data MeltLogical
   = MeltRep ValType
-  | MeltTagSumError -- | MeltTagSum | MeltTagOption
+  | MeltTagSumError
   deriving Eq
 
 repOfMelt :: MeltLogical -> ValType
@@ -339,6 +343,8 @@ instance Pretty Prim where
  pretty (PrimArray (PrimArrayDel _a))
   = "Array_elem_delete#"
 
+ pretty (PrimArray (PrimArrayCopy _a))
+  = "Array_copy#"
 
  pretty (PrimMelt (PrimMeltPack _t))
   = "Melt_pack#"

--- a/icicle-compiler/src/Icicle/Avalanche/Statement/Simp.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Statement/Simp.hs
@@ -15,6 +15,7 @@ module Icicle.Avalanche.Statement.Simp (
   , thresherWithAlpha, thresherNoAlpha
   , nestBlocks
   , dead
+  , linearise
   , killNoEffect
   , stmtFreeX, stmtFreeX'
   , freevarsStmt
@@ -22,6 +23,7 @@ module Icicle.Avalanche.Statement.Simp (
 
 import              Icicle.Avalanche.Statement.Statement
 import              Icicle.Avalanche.Statement.Simp.Dead
+import              Icicle.Avalanche.Statement.Simp.Linear
 import              Icicle.Avalanche.Statement.Simp.ExpEnv
 import              Icicle.Avalanche.Statement.Simp.ThreshOrd
 import              Icicle.Avalanche.Prim.Flat
@@ -293,7 +295,6 @@ renameReads a_fresh statements
 
   splitWrite _ _ _
    = Nothing
-
 
 -- Substitute an expression into a statement.
 --

--- a/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
@@ -111,6 +111,9 @@ constructor a_fresh statements
   primArrayDel i t a
    = xPrim (PrimArray (PrimArrayDel t)) `xApp` a `xApp` i
 
+  primArrayCopy t a
+   = xPrim (PrimArray (PrimArrayCopy t)) `xApp` a
+
   primUnpack ix t x
    = xPrim (PrimMelt (PrimMeltUnpack ix t)) `xApp` x
 
@@ -321,6 +324,12 @@ constructor a_fresh statements
    , Just tis <- withIndex tryMeltType tx
    = Just $ primPack env (ArrayT tx)
    $ fmap (\(t, ix) -> primArraySwap ix1 ix2 t (primUnpack ix (ArrayT tx) na))
+     tis
+
+   | (PrimArray (PrimArrayCopy tx), [na]) <- prima
+   , Just tis <- withIndex tryMeltType tx
+   = Just $ primPack env (ArrayT tx)
+   $ fmap (\(t, ix) -> primArrayCopy t (primUnpack ix (ArrayT tx) na))
      tis
 
    | (PrimArray (PrimArrayDel tx), [na, i]) <- prima

--- a/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/Dead.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/Dead.hs
@@ -71,7 +71,7 @@ deadS us statements
      -> let (sU, sK, sS) = deadS us ss
             xU           = usageX x
         in  if   usedX n sU
-            then (deleteX n (mconcat [xU, sU]), sK, Let n x sS)
+            then (deleteX  n (mconcat [xU, sU]), sK, Let n x sS)
             else (sU, sK, sS)
     While t n nt end ss
      -- While is a bit special. We must ensure writes to the while condition are not removed,

--- a/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/Linear.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/Linear.hs
@@ -1,0 +1,292 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+{-# LANGUAGE PatternGuards      #-}
+{-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE TupleSections      #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE DoAndIfThenElse    #-}
+{-# LANGUAGE RecursiveDo        #-}
+
+-- Remove copy operations on arrays which don't have shared references.
+module Icicle.Avalanche.Statement.Simp.Linear (linearise) where
+
+import              Control.Monad.Tardis
+
+import qualified    Data.Set as Set
+import              Data.Hashable (Hashable (..))
+import qualified    Data.Map.Lazy as Map
+
+import qualified    Icicle.Avalanche.Prim.Flat as Flat
+import              Icicle.Avalanche.Statement.Statement
+import              Icicle.Common.Base (Name)
+import              Icicle.Common.Exp
+import              Icicle.Common.Type (ValType (..))
+
+import              P hiding (empty)
+
+-- | Minimise clones of arrays.
+--
+--   This pass is currently pretty naïve, and is only really designed to make
+--   sure that `group` expressions don't create a new array for their maps
+--   with every new data point added to the map.
+--
+--   The idea is that if arrays are exclusively accessed in an affine manner,
+--   then we don't need to clone them, and can instead act on them destructively.
+--
+--   To do this, we build a graph data structure of all bindings which might
+--   reference the same memory location in a future part of the program.
+--
+--   We also build a usage set where we track what variables are used later
+--   in the program, and propagate that information backwards.
+--
+--   Finally, if we encounter a write which just writes a copy of an array, and
+--   no values which might share a reference are used after this, then we
+--   delete the copy, and just use the original array.
+--
+--   The tricky part here is that information travels in both directions, so we
+--   need to not blow out our runtime.
+--
+linearise :: (Hashable n, Eq n) => Statement a n Flat.Prim -> Statement a n Flat.Prim
+linearise s =
+  evalTardis (go s) (Set.empty, empty)
+    where
+
+  --
+  -- Delete copy operations if they won't change the result when elaborated into C.
+  --
+  -- The Tardis Monad is used to propagate usage information backwards and the alias map
+  -- forwards.
+  --
+  -- It's likely possible this can be done without the Tardis Monad and just with laziness,
+  -- but it seems to make the algorithm simpler, especially for Blocks.
+  go statements =
+    case statements of
+      --
+      -- If blocks are tricky, in that only one will run, so individually shouldn't see
+      -- what the other branch does. Before and after though, we need to accommodate either
+      -- side running. So we break out of the monad, and then merge the results to send each
+      -- way.
+      If x ts fs -> mdo
+        modifyBackwardsUsed (tU <> fU <> freevars x)
+
+        aliased            <- getPast
+        let ~(tS, (tU, tA)) = runTardis (go ts) (used, aliased)
+        let ~(fS, (fU, fA)) = runTardis (go fs) (used, aliased)
+        used               <- getFuture
+
+        modifyForwards $
+          merge tA . merge fA
+
+        return $
+          If x tS fS
+
+      --
+      -- Reads introduce scope for future consideration.
+      -- If it's an array, we say that it aliases the one it points to in the future.
+      Read nx na t@(ArrayT {}) ss -> do
+        modifyBackwardsUsedRemoveBind nx na
+        -- Modify forwards before entering the block
+        modifyForwards $
+          overwrite nx na
+
+        Read nx na t <$> go ss
+
+      --
+      -- It it's not an array, we don't mind and don't declare the alias.
+      Read nx na t ss -> do
+        modifyBackwardsUsedRemoveBind nx na
+        Read nx na t <$> go ss
+
+      --
+      -- Let bindings are a lot like reads, if it looks like a reference, then add
+      -- the alias.
+      Let nm x ss | Just ref <- arrayReference x -> do
+        modifyBackwardsUsedRemoveBind' nm x
+        -- Modify forwards before entering the block
+        modifyForwards $
+          overwrite nm ref
+
+        Let nm x <$> go ss
+
+      Let nm x ss -> do
+        modifyBackwardsUsedRemoveBind' nm x
+        Let nm x <$> go ss
+
+      --
+      -- Initialisation is similar again to lets and reads.
+      InitAccumulator acc@(Accumulator nm (ArrayT {}) x) ss | Just ref <- arrayReference x -> do
+        modifyBackwardsUsedRemoveBind' nm x
+        -- Modify forwards before entering the block
+        modifyForwards $
+          overwrite nm ref
+
+        InitAccumulator acc <$> go ss
+
+      InitAccumulator acc@(Accumulator nm _ x) ss -> do
+        modifyBackwardsUsedRemoveBind' nm x
+        InitAccumulator acc <$> go ss
+
+      --
+      -- Here's the key judgement and rewrite.
+      -- This write just copies some array into an accumulator.
+      -- If the used set of accumulators and names from future
+      -- statements does not include anything which comes from
+      -- the array we are copying, then we don't need to actually
+      -- copy it and can instead use it directly.
+      Write n x | Just (Flat.PrimArray (Flat.PrimArrayCopy _), [XVar a ref]) <- takePrimApps x -> do
+        modifyBackwardsUsed' x
+        aliased <- getPast
+        used    <- getFuture
+
+        -- Do we need to add a new alias for this? If there are no
+        -- further references then we don't delete the copy, then
+        -- there technically should be an alias, but, on the other
+        -- hand, it doesn't matter, because there are no aliases which
+        -- refer to anything before this address or this address so no
+        -- path can be formed; on the other hand, if we do keep the
+        -- copy, then there's no alias required, because it's a fresh
+        -- memory location. Either way, we need to make the same
+        -- decision, because if we change the sent signals here based
+        -- on them, we won't be able to fix the Tardis.
+
+        pure $
+          if hasNoFurtherReferences n ref aliased used then do
+            Write n (XVar a ref)
+          else do
+            Write n x
+
+      --
+      -- Otherwise, if the write is a reference, then we need
+      -- to know that this memory location points to the old
+      -- one in subsequent items in a block.
+      Write n x | Just ref <- arrayReference x -> do
+        modifyBackwardsUsed' x
+        modifyForwards $
+          insert n ref
+
+        pure $ Write n x
+
+      Write n x -> do
+        modifyBackwardsUsed' x
+        pure $ Write n x
+
+      --
+      -- Traverse the block items in order; the future and past
+      -- states will sort themselves out.
+      Block xs ->
+        Block <$> traverse go xs
+
+      While a w vt x ss -> do
+        modifyBackwardsUsed' x
+        While a w vt x <$> go ss
+
+      ForeachInts t n from to ss -> do
+        modifyBackwardsUsed' from
+        modifyBackwardsUsed' to
+        ForeachInts t n from to <$> go ss
+
+      ForeachFacts binds vt ss -> do
+        ForeachFacts binds vt <$> go ss
+
+      x@(Output _ _ xts) -> do
+        for_ xts $
+          modifyBackwardsUsed' . fst
+
+        pure x
+
+    where
+      --
+      -- Can we remove the bindings for lets and reads?
+      -- If we make the assumption that any refs which the binding `n` is made from must
+      -- be derived from the expression `x`, then yes. We're effectively substituting any
+      -- (optional) usages of the downstream named bindings with the usage to create it.
+      -- This should help keep our backwards `Set` small, which is important because we
+      -- need to do a `union` step for our `If` statements, which is effectively `O(N)`
+      -- there, as the sizes of the sets are similar.
+      modifyBackwardsUsedRemoveBind' n x =
+        modifyBackwards (Set.delete n . Set.union (freevars x))
+      modifyBackwardsUsedRemoveBind n acc =
+        modifyBackwards (Set.delete n . Set.insert acc)
+
+      modifyBackwardsUsed =
+        modifyBackwards . Set.union
+      modifyBackwardsUsed' =
+        modifyBackwardsUsed . freevars
+
+
+hasNoFurtherReferences :: Ord a => a -> a -> Graph a -> Set.Set a -> Bool
+hasNoFurtherReferences acc nx aliased used =
+  let
+    theseAliases =
+      Set.insert nx (search [nx] aliased)
+
+    thoseAliases =
+      search (Set.toList (Set.delete acc used)) aliased
+  in
+    Set.disjoint
+      theseAliases
+      thoseAliases
+
+
+arrayReference :: Exp a n Flat.Prim -> Maybe (Name n)
+arrayReference x =
+  case x of
+    XVar _ nm ->
+      Just nm
+
+    _ | Just (Flat.PrimArray (Flat.PrimArrayPutMutable _), [g,_,_]) <- takePrimApps x ->
+      arrayReference g
+
+    _ | Just (Flat.PrimArray (Flat.PrimArraySwap _), [g,_,_]) <- takePrimApps x ->
+      arrayReference g
+
+    _ | Just (Flat.PrimArray (Flat.PrimArrayDel _), [g,_]) <- takePrimApps x ->
+      arrayReference g
+
+    --
+    -- This one's different. Nested arrays in arrays are a bit tricky, especially if we're going
+    -- to consider something like a Heap Sort. Instead, just say all values in a nested array
+    -- share a reference with the top array.
+    _ | Just (Flat.PrimUnsafe (Flat.PrimUnsafeArrayIndex (ArrayT {})), [g,_]) <- takePrimApps x ->
+      arrayReference g
+
+    _ ->
+      Nothing
+
+--
+-- | Dead simple graph library for doing a search.
+newtype Graph n =
+  Graph (Map.Map n (Set.Set n))
+ deriving (Eq, Ord, Show)
+
+empty :: Graph n
+empty =
+  Graph Map.empty
+
+insert :: Ord n => n -> n -> Graph n -> Graph n
+insert from to (Graph g) =
+  Graph $
+    Map.alter (Just . maybe (Set.singleton to) (Set.insert to)) from g
+
+overwrite :: Ord n => n -> n -> Graph n -> Graph n
+overwrite from to (Graph g) =
+  Graph $
+    Map.insert from (Set.singleton to) g
+
+match :: Ord n => n -> Graph n -> (Set.Set n, Graph n)
+match n (Graph g) =
+  case Map.lookup n g of
+    Nothing -> (Set.empty, Graph g)
+    Just set -> (set, Graph $ Map.delete n g)
+
+search :: Ord n => [n] -> Graph n -> Set.Set n
+search [] _ = Set.empty
+search ns g =
+  let go (s', g') n'   = let (found', remains') = match n' g' in (Set.union s' found', remains')
+      (found, remains) = foldl' go (Set.empty, g) ns
+  in Set.union found (search (Set.toList found) remains)
+
+merge :: Ord n => Graph n -> Graph n -> Graph n
+merge (Graph a) (Graph b) =
+  Graph $
+    Map.unionWith Set.union a b

--- a/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/Melt.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/Melt.hs
@@ -174,8 +174,6 @@ meltOutputs :: forall a n. a
 meltOutputs a_fresh statements
  = transformUDStmt goStmt () statements
  where
-  MeltOps{..} = meltOps a_fresh
-
   goStmt () stmt
    = case stmt of
        Output n t xts

--- a/icicle-compiler/src/Icicle/Avalanche/Statement/Statement.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Statement/Statement.hs
@@ -219,11 +219,13 @@ instance TransformX Statement where
   = case stmt of
      If x ss es
       -> If <$> exps x <*> go ss <*> go es
+
      Let n x ss
       -> Let <$> names n <*> exps x <*> go ss
 
      While t n vt end ss
       -> While t <$> names n <*> pure vt <*> exps end <*> go ss
+
      ForeachInts t n from to ss
       -> ForeachInts t <$> names n <*> exps from <*> exps to <*> go ss
 
@@ -239,6 +241,7 @@ instance TransformX Statement where
 
      Read n acc vt ss
       -> Read <$> names n <*> names acc <*> pure vt <*> go ss
+
      Write n x
       -> Write <$> names n <*> exps x
 

--- a/icicle-compiler/src/Icicle/Avalanche/Statement/Statement.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Statement/Statement.hs
@@ -16,6 +16,7 @@ module Icicle.Avalanche.Statement.Statement (
   , factBindsAll
   ) where
 
+import           Control.Lens (Plated (..))
 import           GHC.Generics (Generic)
 
 import           Icicle.Common.Base
@@ -128,6 +129,31 @@ instance NFData WhileType
 
 -- Transforming -------------
 
+instance Plated (Statement a n p) where
+  plate f = \case
+    If x ss es
+      -> If x <$> f ss <*> f es
+    Let n x ss
+      -> Let n x <$> f ss
+    While t n vt end ss
+      -> While t n vt end <$> f ss
+    ForeachInts t n from to ss
+      -> ForeachInts t n from to <$> f ss
+    ForeachFacts binds ty ss
+      -> ForeachFacts binds ty <$> f ss
+    Block ss
+      -> Block <$> traverse f ss
+    InitAccumulator acc ss
+      -> InitAccumulator acc <$> f ss
+    Read n acc vt ss
+      -> Read n acc vt <$> f ss
+    x @ Write {}
+      -> pure x
+    x @ Output {}
+      -> pure x
+  {-# INLINABLE plate #-}
+
+-- | Transform with a monadic effect in a top down manner
 transformUDStmt
         :: Monad m
         => (env -> Statement a n p -> m (env, Statement a n p))
@@ -139,27 +165,7 @@ transformUDStmt fun env statements
  where
   go e s
    = do  (e', s') <- fun e s
-         case s' of
-          If x ss es
-           -> If x <$> go e' ss <*> go e' es
-          Let n x ss
-           -> Let n x <$> go e' ss
-          While t n vt end ss
-           -> While t n vt end <$> go e' ss
-          ForeachInts t n from to ss
-           -> ForeachInts t n from to <$> go e' ss
-          ForeachFacts binds ty ss
-           -> ForeachFacts binds ty <$> go e' ss
-          Block ss
-           -> Block <$> mapM (go e') ss
-          InitAccumulator acc ss
-           -> InitAccumulator acc <$> go e' ss
-          Read n acc vt ss
-           -> Read n acc vt <$> go e' ss
-          Write n x
-           -> return $ Write n x
-          Output n t xs
-           -> return $ Output n t xs
+         plate (go e') s'
 {-# INLINE transformUDStmt #-}
 
 

--- a/icicle-compiler/src/Icicle/Repl/Source.hs
+++ b/icicle-compiler/src/Icicle/Repl/Source.hs
@@ -27,6 +27,7 @@ getCheckOptions = do
   else
     pure Source.optionSmallData
 
+
 getEvalContext :: Repl EvalContext
 getEvalContext = do
   s <- get

--- a/icicle-compiler/src/Icicle/Sea/FromAvalanche/Prim.hs
+++ b/icicle-compiler/src/Icicle/Sea/FromAvalanche/Prim.hs
@@ -204,6 +204,8 @@ seaOfPrimArray p
       -> PDAlloc (prefixOfValType (ArrayT t) <> "put_immutable") Nothing
      PrimArraySwap t
       -> PDFun   (prefixOfValType (ArrayT t) <> "swap") Nothing
+     PrimArrayCopy t
+      -> PDAlloc (prefixOfValType (ArrayT t) <> "copy") Nothing
      PrimArrayDel t
       -> PDAlloc   (prefixOfValType (ArrayT t) <> "delete") Nothing
      PrimArrayZip _ _

--- a/icicle-compiler/test/Icicle/Test/Avalanche/Simp/Linear.hs
+++ b/icicle-compiler/test/Icicle/Test/Avalanche/Simp/Linear.hs
@@ -1,0 +1,217 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE LambdaCase #-}
+module Icicle.Test.Avalanche.Simp.Linear where
+
+import           Control.Lens.Plated
+import           Data.Monoid (Sum(..))
+
+
+import           Icicle.Avalanche.Statement.Flatten.Algorithms
+import           Icicle.Common.Type (ValType(..))
+
+import           P
+import           Hedgehog hiding (Var)
+import           System.IO
+import           Icicle.Common.Base
+import           Icicle.Common.Exp
+import           Icicle.Common.Fresh
+import           Icicle.Avalanche.Statement.Statement
+import qualified Icicle.Avalanche.Prim.Flat as Flat
+import qualified Icicle.Avalanche.Prim.Compounds as Flat
+import           Icicle.Avalanche.Statement.Simp.Linear (linearise)
+import           Icicle.Test.Arbitrary.Core (testFresh)
+import           Icicle.Test.Arbitrary.Data (Var)
+
+
+--
+-- This program trivially doesn't need to do the copy,
+-- as the very last statement is a copy and nothing after
+-- it is used.
+simple_copy_elide :: a -> Fresh Var (Statement a Var Flat.Prim)
+simple_copy_elide a_fresh = do
+  acc  <- freshPrefix "test_arr"
+  loc  <- freshPrefix "loc"
+  dest <- freshPrefix "dest"
+
+  return
+    $ initArr IntT acc (XValue a_fresh (ArrayT IntT) (VArray []))
+    $ readArr IntT loc acc
+    $ Block [
+        Write dest (arrCpy IntT (xVar loc))
+      ]
+
+ where
+  Flat.FlatOps  {..} = Flat.flatOps a_fresh
+  Flat.FlatCons {..} = Flat.flatCons a_fresh
+
+--
+-- This program has two copies, one of which can be removed.
+-- The first one can not be, because if it were, then the second
+-- data point would point to a mutable shared memory location.
+simple_copy_retain :: a -> Fresh Var (Statement a Var Flat.Prim)
+simple_copy_retain a_fresh = do
+  acc    <- freshPrefix "test_arr"
+  loc    <- freshPrefix "loc"
+  dest   <- freshPrefix "dest"
+  dest2  <- freshPrefix "dest"
+
+  return
+    $ initArr IntT acc (XValue a_fresh (ArrayT IntT) (VArray []))
+    $ readArr IntT loc acc
+    $ Block [
+        Write dest (arrCpy IntT (xVar loc))
+      , Write dest2 (arrCpy IntT (xVar loc))
+      ]
+
+ where
+  Flat.FlatOps  {..} = Flat.flatOps a_fresh
+  Flat.FlatCons {..} = Flat.flatCons a_fresh
+
+
+--
+-- This program uses a write in a block to introduce the
+-- shared reference. We need to track that moving forwards through
+-- the statements too.
+write_ref_copy :: a -> Fresh Var (Statement a Var Flat.Prim)
+write_ref_copy a_fresh = do
+  acc    <- freshPrefix "test_arr"
+  acc2   <- freshPrefix "test_arr"
+  loc    <- freshPrefix "loc"
+  loc2   <- freshPrefix "loc"
+  dest   <- freshPrefix "dest"
+  dest2  <- freshPrefix "dest2"
+
+  return
+    $ initArr IntT acc (XValue a_fresh (ArrayT IntT) (VArray [VInt 1]))
+    $ initArr IntT acc2 (XValue a_fresh (ArrayT IntT) (VArray [VInt 2]))
+    $ readArr IntT loc2 acc2
+    $ Block[
+        Write acc (xVar loc2)
+      , readArr IntT loc acc
+        $ Block [
+            Write dest (arrCpy IntT (xVar loc))
+          , Write dest2 (arrCpy IntT (xVar loc2))
+          ]
+    ]
+
+ where
+  Flat.FlatOps  {..} = Flat.flatOps a_fresh
+  Flat.FlatCons {..} = Flat.flatCons a_fresh
+
+
+--
+-- This program uses has writes in an if block.
+-- Both copies before the last need to be preserved
+write_ref_in_if_copy :: a -> Fresh Var (Statement a Var Flat.Prim)
+write_ref_in_if_copy a_fresh = do
+  acc    <- freshPrefix "test_arr"
+  acc2   <- freshPrefix "test_arr"
+  acc3   <- freshPrefix "test_arr"
+  loc    <- freshPrefix "loc"
+  loc2   <- freshPrefix "loc"
+  loc3   <- freshPrefix "loc"
+  dest   <- freshPrefix "dest"
+  dest2  <- freshPrefix "dest2"
+  dest3  <- freshPrefix "dest2"
+
+  return
+    $ initArr IntT acc (XValue a_fresh (ArrayT IntT) (VArray [VInt 1]))
+    $ initArr IntT acc2 (XValue a_fresh (ArrayT IntT) (VArray [VInt 2]))
+    $ initArr IntT acc3 (XValue a_fresh (ArrayT IntT) (VArray [VInt 3]))
+    $ readArr IntT loc2 acc2
+    $ Block[
+        If (xTrue) (Write acc (xVar loc2)) (Write acc3 (xVar loc2))
+      , readArr IntT loc acc
+      $ readArr IntT loc3 acc3
+        $ Block [
+            Write dest (arrCpy IntT (xVar loc))
+          , Write dest2 (arrCpy IntT (xVar loc2))
+          , Write dest3 (arrCpy IntT (xVar loc3))
+          ]
+    ]
+
+ where
+  xTrue  = xValue BoolT (VBool True)
+
+  Flat.FlatOps  {..} = Flat.flatOps a_fresh
+  Flat.FlatCons {..} = Flat.flatCons a_fresh
+
+--
+--
+write_ref_out_of_scope_let_copy :: a -> Fresh Var (Statement a Var Flat.Prim)
+write_ref_out_of_scope_let_copy a_fresh = do
+  acc    <- freshPrefix "test_arr"
+  acc2   <- freshPrefix "test_arr"
+  loc    <- freshPrefix "loc"
+  loc2   <- freshPrefix "loc"
+  loc3   <- freshPrefix "loc"
+  dest   <- freshPrefix "dest"
+  dest2  <- freshPrefix "dest2"
+
+  return
+    $ initArr IntT acc (XValue a_fresh (ArrayT IntT) (VArray [VInt 1]))
+    $ initArr IntT acc2 (XValue a_fresh (ArrayT IntT) (VArray [VInt 2]))
+    $ readArr IntT loc2 acc2
+    $ Block[
+        Let loc3 (xVar loc2) (Write acc (arrCpy IntT (xVar loc3)))
+      , readArr IntT loc acc
+        $ Block [
+            Write dest (arrCpy IntT (xVar loc))
+          , Write dest2 (arrCpy IntT (xVar loc2))
+          ]
+    ]
+
+ where
+  Flat.FlatOps  {..} = Flat.flatOps a_fresh
+  Flat.FlatCons {..} = Flat.flatCons a_fresh
+
+
+countCopies :: TransformX x => x () n Flat.Prim -> Integer
+countCopies a =
+  getSum . getConst $
+    transformX pure isCopy a
+
+
+isCopy :: Exp () n Flat.Prim -> Const (Sum Integer) (Exp () n Flat.Prim)
+isCopy e =
+  case e of
+    XPrim () (Flat.PrimArray (Flat.PrimArrayCopy _)) -> Const (Sum 1)
+    _ -> plate isCopy e
+
+prop_elides_copy :: Property
+prop_elides_copy
+ = withTests 1 . property $ do
+     ((=== 0) . countCopies) $
+       linearise (testFresh "a" $ simple_copy_elide ())
+
+prop_keeps_copy :: Property
+prop_keeps_copy
+ = withTests 1 . property $ do
+     ((=== 1) . countCopies) $
+       linearise (testFresh "a" $ simple_copy_retain ())
+
+prop_write_ref_copy :: Property
+prop_write_ref_copy
+ = withTests 1 . property $ do
+     ((=== 1) . countCopies) $
+       linearise (testFresh "a" $ write_ref_copy ())
+
+prop_write_ref_in_if_copy :: Property
+prop_write_ref_in_if_copy
+ = withTests 1 . property $ do
+     ((=== 2) . countCopies) $
+       linearise (testFresh "a" $ write_ref_in_if_copy ())
+
+prop_write_ref_out_of_scope_let_copy :: Property
+prop_write_ref_out_of_scope_let_copy
+ = withTests 1 . property $ do
+     ((=== 1) . countCopies) $
+       linearise (testFresh "a" $ write_ref_out_of_scope_let_copy ())
+
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)

--- a/icicle-compiler/test/cli/repl/t10.3-flatten/expected
+++ b/icicle-compiler/test/cli/repl/t10.3-flatten/expected
@@ -342,102 +342,100 @@ conv-2 : Time =
 conv-3 : Int =
   MAX_MAP_SIZE
 
-acc-conv-34-simpflat-30 =i ExceptNotAnError : Error
-acc-conv-34-simpflat-31 =i unsafe_Array_create#
+acc-conv-34-simpflat-28 =i ExceptNotAnError : Error
+acc-conv-34-simpflat-29 =i unsafe_Array_create#
                              0 : Array Time
-acc-conv-34-simpflat-32 =i unsafe_Array_create#
+acc-conv-34-simpflat-30 =i unsafe_Array_create#
                              0 : Array (Buf 2 Error)
-acc-conv-34-simpflat-33 =i unsafe_Array_create#
+acc-conv-34-simpflat-31 =i unsafe_Array_create#
                              0 : Array (Buf 2 Int)
 
 for_facts conv-1 : Time
-        , conv-0-simpflat-127 : Error
-        , conv-0-simpflat-128 : Int
-        , conv-0-simpflat-129 : Time {
+        , conv-0-simpflat-134 : Error
+        , conv-0-simpflat-135 : Int
+        , conv-0-simpflat-136 : Time {
+    conv-34-aval-0-simpflat-33 =r acc-conv-34-simpflat-28
+    conv-34-aval-0-simpflat-34 =r acc-conv-34-simpflat-29
     conv-34-aval-0-simpflat-35 =r acc-conv-34-simpflat-30
     conv-34-aval-0-simpflat-36 =r acc-conv-34-simpflat-31
-    conv-34-aval-0-simpflat-37 =r acc-conv-34-simpflat-32
-    conv-34-aval-0-simpflat-38 =r acc-conv-34-simpflat-33
-    flat-0-simpflat-40 =i ExceptNotAnError : Error
-    flat-0-simpflat-41 =i unsafe_Array_create#
+    flat-0-simpflat-38 =i ExceptNotAnError : Error
+    flat-0-simpflat-39 =i unsafe_Array_create#
                             0 : Array Time
-    flat-0-simpflat-42 =i unsafe_Array_create#
+    flat-0-simpflat-40 =i unsafe_Array_create#
                             0 : Array (Buf 2 Error)
-    flat-0-simpflat-43 =i unsafe_Array_create#
+    flat-0-simpflat-41 =i unsafe_Array_create#
                             0 : Array (Buf 2 Int)
     
     if (eq#
-          conv-34-aval-0-simpflat-35
+          conv-34-aval-0-simpflat-33
           ExceptNotAnError)
     {
-        map_insert_acc_keys-flat-3 =i conv-34-aval-0-simpflat-36 : Array Time
-        map_insert_acc_vals-flat-4-simpflat-45 =i conv-34-aval-0-simpflat-37 : Array (Buf 2 Error)
-        map_insert_acc_vals-flat-4-simpflat-46 =i conv-34-aval-0-simpflat-38 : Array (Buf 2 Int)
+        map_insert_acc_keys-flat-3 =i conv-34-aval-0-simpflat-34 : Array Time
+        map_insert_acc_vals-flat-4-simpflat-43 =i conv-34-aval-0-simpflat-35 : Array (Buf 2 Error)
+        map_insert_acc_vals-flat-4-simpflat-44 =i conv-34-aval-0-simpflat-36 : Array (Buf 2 Int)
         map_insert_acc_bs_found-flat-6 =i False : Bool
         map_insert_acc_bs_index-flat-5 =i -1 : Int
         map_insert_loc_keys-flat-7 =r map_insert_acc_keys-flat-3
-        map_insert_loc_vals-flat-8-simpflat-48 =r map_insert_acc_vals-flat-4-simpflat-45
-        map_insert_loc_vals-flat-8-simpflat-49 =r map_insert_acc_vals-flat-4-simpflat-46
-        map_insert_size-flat-12 = Array_length#
+        map_insert_size-flat-14 = Array_length#
                                     map_insert_loc_keys-flat-7
-        bs_acc_found-flat-20 =i False : Bool
-        bs_acc_mid-flat-17 =i -1 : Int
-        bs_acc_ins-flat-19 =i -1 : Int
-        bs_acc_low-flat-25 =i 0 : Int
-        bs_acc_high-flat-26 =i sub#
-                                 map_insert_size-flat-12
+        bs_acc_found-flat-22 =i False : Bool
+        bs_acc_mid-flat-19 =i -1 : Int
+        bs_acc_ins-flat-21 =i -1 : Int
+        bs_acc_low-flat-27 =i 0 : Int
+        bs_acc_high-flat-28 =i sub#
+                                 map_insert_size-flat-14
                                  1 : Int
-        bs_acc_end-flat-27 =i False : Bool
+        bs_acc_end-flat-29 =i False : Bool
         
-        while (bs_acc_end-flat-27 == False)
+        while (bs_acc_end-flat-29 == False)
         {
-            bs_loc_low-flat-23 =r bs_acc_low-flat-25
-            bs_loc_high-flat-24 =r bs_acc_high-flat-26
+            bs_loc_low-flat-25 =r bs_acc_low-flat-27
+            bs_loc_high-flat-26 =r bs_acc_high-flat-28
             
             if (gt#
-                  bs_loc_low-flat-23
-                  bs_loc_high-flat-24)
+                  bs_loc_low-flat-25
+                  bs_loc_high-flat-26)
             {
-                bs_acc_end-flat-27 =w True
-                bs_acc_ins-flat-19 =w bs_loc_low-flat-23
+                bs_acc_end-flat-29 =w True
+                bs_acc_ins-flat-21 =w bs_loc_low-flat-25
             }
             else
             {
                 simpflat-1 = add#
-                               bs_loc_low-flat-23
-                               bs_loc_high-flat-24
+                               bs_loc_low-flat-25
+                               bs_loc_high-flat-26
                 simpflat-2 = doubleOfInt#
                                simpflat-1
                 simpflat-3 = div# simpflat-2 2.0
-                bs_acc_mid-flat-17 =w floor#
+                bs_acc_mid-flat-19 =w floor#
                                         simpflat-3
-                bs_loc_mid-flat-21 =r bs_acc_mid-flat-17
-                bs_loc_x-flat-22 = unsafe_Array_index#
+                bs_loc_mid-flat-23 =r bs_acc_mid-flat-19
+                bs_loc_x-flat-24 = unsafe_Array_index#
                                      map_insert_loc_keys-flat-7
-                                     bs_loc_mid-flat-21
+                                     bs_loc_mid-flat-23
                 
                 if (eq#
-                      bs_loc_x-flat-22
-                      conv-0-simpflat-129)
+                      bs_loc_x-flat-24
+                      conv-0-simpflat-136)
                 {
-                    bs_acc_end-flat-27 =w True
-                    bs_acc_found-flat-20 =w True
+                    bs_acc_end-flat-29 =w True
+                    bs_acc_found-flat-22 =w True
                 }
                 else
                 {
                     
                     if (lt#
-                          bs_loc_x-flat-22
-                          conv-0-simpflat-129)
+                          bs_loc_x-flat-24
+                          conv-0-simpflat-136)
                     {
-                        bs_acc_low-flat-25 =w add#
-                                                bs_loc_mid-flat-21
+                        bs_acc_low-flat-27 =w add#
+                                                bs_loc_mid-flat-23
                                                 1
                     }
                     else
                     {
-                        bs_acc_high-flat-26 =w sub#
-                                                 bs_loc_mid-flat-21
+                        bs_acc_high-flat-28 =w sub#
+                                                 bs_loc_mid-flat-23
                                                  1
                     }
                     
@@ -447,403 +445,392 @@ for_facts conv-1 : Time
             
         }
         
-        bs_loc_found-flat-15 =r bs_acc_found-flat-20
-        bs_loc_mid-flat-16 =r bs_acc_mid-flat-17
-        bs_loc_ins-flat-18 =r bs_acc_ins-flat-19
+        bs_loc_found-flat-17 =r bs_acc_found-flat-22
+        bs_loc_mid-flat-18 =r bs_acc_mid-flat-19
+        bs_loc_ins-flat-20 =r bs_acc_ins-flat-21
         
         if (eq#
-              bs_loc_found-flat-15
+              bs_loc_found-flat-17
               True)
         {
             map_insert_acc_bs_found-flat-6 =w True
-            map_insert_acc_bs_index-flat-5 =w bs_loc_mid-flat-16
+            map_insert_acc_bs_index-flat-5 =w bs_loc_mid-flat-18
         }
         else
         {
             map_insert_acc_bs_found-flat-6 =w False
-            map_insert_acc_bs_index-flat-5 =w bs_loc_ins-flat-18
+            map_insert_acc_bs_index-flat-5 =w bs_loc_ins-flat-20
         }
         
-        flat-101 =r map_insert_acc_bs_found-flat-6
-        flat-102 =r map_insert_acc_bs_index-flat-5
+        flat-105 =r map_insert_acc_bs_found-flat-6
+        flat-106 =r map_insert_acc_bs_index-flat-5
         
-        if (eq# flat-101 True)
+        if (eq# flat-105 True)
         {
-            simpflat-240 = unsafe_Array_index#
-                             map_insert_loc_vals-flat-8-simpflat-48
-                             flat-102
-            simpflat-242 = unsafe_Array_index#
-                             map_insert_loc_vals-flat-8-simpflat-49
-                             flat-102
-            simpflat-247 = Buf_push#
-                             simpflat-240
-                             conv-0-simpflat-127
-            simpflat-250 = Buf_push#
-                             simpflat-242
-                             conv-0-simpflat-128
-            map_insert_acc_vals-flat-4-simpflat-45 =r map_insert_acc_vals-flat-4-simpflat-45
-            map_insert_acc_vals-flat-4-simpflat-45 =w Array_put_immutable#
-                                                        map_insert_acc_vals-flat-4-simpflat-45
-                                                        flat-102
-                                                        simpflat-247
-            map_insert_acc_vals-flat-4-simpflat-46 =r map_insert_acc_vals-flat-4-simpflat-46
-            map_insert_acc_vals-flat-4-simpflat-46 =w Array_put_immutable#
-                                                        map_insert_acc_vals-flat-4-simpflat-46
-                                                        flat-102
-                                                        simpflat-250
+            copy_array-flat-34-simpflat-49 =r map_insert_acc_vals-flat-4-simpflat-43
+            copy_array-flat-34-simpflat-50 =r map_insert_acc_vals-flat-4-simpflat-44
+            simpflat-4 = Array_length#
+                           copy_array-flat-34-simpflat-49
+            
+            if (ne# simpflat-4 0)
+            {
+                map_insert_acc_vals-flat-4-simpflat-43 =w copy_array-flat-34-simpflat-49
+                map_insert_acc_vals-flat-4-simpflat-44 =w copy_array-flat-34-simpflat-50
+            }
+            
+            map_insert_cpy_vals-flat-10-simpflat-52 =r map_insert_acc_vals-flat-4-simpflat-43
+            map_insert_cpy_vals-flat-10-simpflat-53 =r map_insert_acc_vals-flat-4-simpflat-44
+            simpflat-257 = unsafe_Array_index#
+                             map_insert_cpy_vals-flat-10-simpflat-52
+                             flat-106
+            simpflat-259 = unsafe_Array_index#
+                             map_insert_cpy_vals-flat-10-simpflat-53
+                             flat-106
+            simpflat-264 = Buf_push#
+                             simpflat-257
+                             conv-0-simpflat-134
+            simpflat-267 = Buf_push#
+                             simpflat-259
+                             conv-0-simpflat-135
+            map_insert_acc_vals-flat-4-simpflat-43 =r map_insert_acc_vals-flat-4-simpflat-43
+            map_insert_acc_vals-flat-4-simpflat-43 =w Array_put_mutable#
+                                                        map_insert_acc_vals-flat-4-simpflat-43
+                                                        flat-106
+                                                        simpflat-264
+            map_insert_acc_vals-flat-4-simpflat-44 =r map_insert_acc_vals-flat-4-simpflat-44
+            map_insert_acc_vals-flat-4-simpflat-44 =w Array_put_mutable#
+                                                        map_insert_acc_vals-flat-4-simpflat-44
+                                                        flat-106
+                                                        simpflat-267
         }
         else
         {
-            copy_array-flat-31 =r map_insert_acc_keys-flat-3
-            simpflat-4 = Array_length#
-                           copy_array-flat-31
+            copy_array-flat-33 =r map_insert_acc_keys-flat-3
+            simpflat-5 = Array_length#
+                           copy_array-flat-33
             
-            if (eq# simpflat-4 0)
+            if (ne# simpflat-5 0)
             {
-                
-            }
-            else
-            {
-                simpflat-5 = unsafe_Array_index#
-                               copy_array-flat-31
-                               0
-                map_insert_acc_keys-flat-3 =w Array_put_immutable#
-                                                copy_array-flat-31
-                                                0
-                                                simpflat-5
+                map_insert_acc_keys-flat-3 =w copy_array-flat-33
             }
             
-            copy_array-flat-32-simpflat-54 =r map_insert_acc_vals-flat-4-simpflat-45
-            copy_array-flat-32-simpflat-55 =r map_insert_acc_vals-flat-4-simpflat-46
+            flat-107-simpflat-58 =r map_insert_acc_vals-flat-4-simpflat-43
+            flat-107-simpflat-59 =r map_insert_acc_vals-flat-4-simpflat-44
             simpflat-6 = Array_length#
-                           copy_array-flat-32-simpflat-54
+                           flat-107-simpflat-58
             
-            if (eq# simpflat-6 0)
+            if (ne# simpflat-6 0)
             {
-                
-            }
-            else
-            {
-                simpflat-262 = unsafe_Array_index#
-                                 copy_array-flat-32-simpflat-54
-                                 0
-                simpflat-264 = unsafe_Array_index#
-                                 copy_array-flat-32-simpflat-55
-                                 0
-                map_insert_acc_vals-flat-4-simpflat-45 =w Array_put_immutable#
-                                                            copy_array-flat-32-simpflat-54
-                                                            0
-                                                            simpflat-262
-                map_insert_acc_vals-flat-4-simpflat-46 =w Array_put_immutable#
-                                                            copy_array-flat-32-simpflat-55
-                                                            0
-                                                            simpflat-264
+                map_insert_acc_vals-flat-4-simpflat-43 =w flat-107-simpflat-58
+                map_insert_acc_vals-flat-4-simpflat-44 =w flat-107-simpflat-59
             }
             
+            map_insert_cpy_keys-flat-9 =r map_insert_acc_keys-flat-3
+            flat-108-simpflat-61 =r map_insert_acc_vals-flat-4-simpflat-43
+            flat-108-simpflat-62 =r map_insert_acc_vals-flat-4-simpflat-44
             
-            foreach (for_counter-flat-33 in map_insert_size-flat-12 .. flat-102)
+            foreach (for_counter-flat-35 in map_insert_size-flat-14 .. flat-106)
             {
-                update_acc-flat-34 =r map_insert_acc_keys-flat-3
-                simpflat-8 = sub#
-                               for_counter-flat-33
+                update_acc-flat-36 =r map_insert_acc_keys-flat-3
+                simpflat-7 = sub#
+                               for_counter-flat-35
                                1
-                simpflat-9 = unsafe_Array_index#
-                               map_insert_loc_keys-flat-7
-                               simpflat-8
+                simpflat-8 = unsafe_Array_index#
+                               map_insert_cpy_keys-flat-9
+                               simpflat-7
                 map_insert_acc_keys-flat-3 =w Array_put_mutable#
-                                                update_acc-flat-34
-                                                for_counter-flat-33
-                                                simpflat-9
-                update_acc-flat-35-simpflat-57 =r map_insert_acc_vals-flat-4-simpflat-45
-                update_acc-flat-35-simpflat-58 =r map_insert_acc_vals-flat-4-simpflat-46
-                simpflat-274 = unsafe_Array_index#
-                                 map_insert_loc_vals-flat-8-simpflat-48
-                                 simpflat-8
-                simpflat-276 = unsafe_Array_index#
-                                 map_insert_loc_vals-flat-8-simpflat-49
-                                 simpflat-8
-                map_insert_acc_vals-flat-4-simpflat-45 =w Array_put_mutable#
-                                                            update_acc-flat-35-simpflat-57
-                                                            for_counter-flat-33
-                                                            simpflat-274
-                map_insert_acc_vals-flat-4-simpflat-46 =w Array_put_mutable#
-                                                            update_acc-flat-35-simpflat-58
-                                                            for_counter-flat-33
-                                                            simpflat-276
+                                                update_acc-flat-36
+                                                for_counter-flat-35
+                                                simpflat-8
+                update_acc-flat-37-simpflat-64 =r map_insert_acc_vals-flat-4-simpflat-43
+                update_acc-flat-37-simpflat-65 =r map_insert_acc_vals-flat-4-simpflat-44
+                simpflat-282 = unsafe_Array_index#
+                                 flat-108-simpflat-61
+                                 simpflat-7
+                simpflat-284 = unsafe_Array_index#
+                                 flat-108-simpflat-62
+                                 simpflat-7
+                map_insert_acc_vals-flat-4-simpflat-43 =w Array_put_mutable#
+                                                            update_acc-flat-37-simpflat-64
+                                                            for_counter-flat-35
+                                                            simpflat-282
+                map_insert_acc_vals-flat-4-simpflat-44 =w Array_put_mutable#
+                                                            update_acc-flat-37-simpflat-65
+                                                            for_counter-flat-35
+                                                            simpflat-284
             }
             
             map_insert_acc_keys-flat-3 =r map_insert_acc_keys-flat-3
             map_insert_acc_keys-flat-3 =w Array_put_mutable#
                                             map_insert_acc_keys-flat-3
-                                            flat-102
-                                            conv-0-simpflat-129
-            simpflat-351 = Buf_make# ()
-            simpflat-286 = Buf_push#
-                             simpflat-351
-                             conv-0-simpflat-127
-            simpflat-352 = Buf_make# ()
-            simpflat-288 = Buf_push#
-                             simpflat-352
-                             conv-0-simpflat-128
-            map_insert_acc_vals-flat-4-simpflat-45 =r map_insert_acc_vals-flat-4-simpflat-45
-            map_insert_acc_vals-flat-4-simpflat-45 =w Array_put_mutable#
-                                                        map_insert_acc_vals-flat-4-simpflat-45
-                                                        flat-102
-                                                        simpflat-286
-            map_insert_acc_vals-flat-4-simpflat-46 =r map_insert_acc_vals-flat-4-simpflat-46
-            map_insert_acc_vals-flat-4-simpflat-46 =w Array_put_mutable#
-                                                        map_insert_acc_vals-flat-4-simpflat-46
-                                                        flat-102
-                                                        simpflat-288
+                                            flat-106
+                                            conv-0-simpflat-136
+            simpflat-359 = Buf_make# ()
+            simpflat-294 = Buf_push#
+                             simpflat-359
+                             conv-0-simpflat-134
+            simpflat-360 = Buf_make# ()
+            simpflat-296 = Buf_push#
+                             simpflat-360
+                             conv-0-simpflat-135
+            map_insert_acc_vals-flat-4-simpflat-43 =r map_insert_acc_vals-flat-4-simpflat-43
+            map_insert_acc_vals-flat-4-simpflat-43 =w Array_put_mutable#
+                                                        map_insert_acc_vals-flat-4-simpflat-43
+                                                        flat-106
+                                                        simpflat-294
+            map_insert_acc_vals-flat-4-simpflat-44 =r map_insert_acc_vals-flat-4-simpflat-44
+            map_insert_acc_vals-flat-4-simpflat-44 =w Array_put_mutable#
+                                                        map_insert_acc_vals-flat-4-simpflat-44
+                                                        flat-106
+                                                        simpflat-296
         }
         
-        flat-103 =r map_insert_acc_keys-flat-3
-        flat-104-simpflat-63 =r map_insert_acc_vals-flat-4-simpflat-45
-        flat-104-simpflat-64 =r map_insert_acc_vals-flat-4-simpflat-46
-        flat-39-simpflat-66 =i ExceptNotAnError : Error
-        flat-39-simpflat-67 =i unsafe_Array_create#
+        flat-109 =r map_insert_acc_keys-flat-3
+        flat-110-simpflat-70 =r map_insert_acc_vals-flat-4-simpflat-43
+        flat-110-simpflat-71 =r map_insert_acc_vals-flat-4-simpflat-44
+        flat-41-simpflat-73 =i ExceptNotAnError : Error
+        flat-41-simpflat-74 =i unsafe_Array_create#
                                  0 : Array Time
-        flat-39-simpflat-68 =i unsafe_Array_create#
+        flat-41-simpflat-75 =i unsafe_Array_create#
                                  0 : Array (Buf 2 Error)
-        flat-39-simpflat-69 =i unsafe_Array_create#
+        flat-41-simpflat-76 =i unsafe_Array_create#
                                  0 : Array (Buf 2 Int)
-        simpflat-13 = Array_length#
-                        flat-103
+        simpflat-12 = Array_length#
+                        flat-109
         
-        if (lt# simpflat-13 conv-3)
+        if (lt# simpflat-12 conv-3)
         {
-            flat-39-simpflat-66 =w ExceptNotAnError
-            flat-39-simpflat-67 =w flat-103
-            flat-39-simpflat-68 =w flat-104-simpflat-63
-            flat-39-simpflat-69 =w flat-104-simpflat-64
+            flat-41-simpflat-73 =w ExceptNotAnError
+            flat-41-simpflat-74 =w flat-109
+            flat-41-simpflat-75 =w flat-110-simpflat-70
+            flat-41-simpflat-76 =w flat-110-simpflat-71
         }
         else
         {
-            flat-39-simpflat-66 =w ExceptCannotCompute
-            flat-39-simpflat-67 =w unsafe_Array_create#
+            flat-41-simpflat-73 =w ExceptCannotCompute
+            flat-41-simpflat-74 =w unsafe_Array_create#
                                      0
-            flat-39-simpflat-68 =w unsafe_Array_create#
+            flat-41-simpflat-75 =w unsafe_Array_create#
                                      0
-            flat-39-simpflat-69 =w unsafe_Array_create#
+            flat-41-simpflat-76 =w unsafe_Array_create#
                                      0
         }
         
-        flat-39-simpflat-71 =r flat-39-simpflat-66
-        flat-39-simpflat-72 =r flat-39-simpflat-67
-        flat-39-simpflat-73 =r flat-39-simpflat-68
-        flat-39-simpflat-74 =r flat-39-simpflat-69
-        flat-0-simpflat-40 =w flat-39-simpflat-71
-        flat-0-simpflat-41 =w flat-39-simpflat-72
-        flat-0-simpflat-42 =w flat-39-simpflat-73
-        flat-0-simpflat-43 =w flat-39-simpflat-74
+        flat-41-simpflat-78 =r flat-41-simpflat-73
+        flat-41-simpflat-79 =r flat-41-simpflat-74
+        flat-41-simpflat-80 =r flat-41-simpflat-75
+        flat-41-simpflat-81 =r flat-41-simpflat-76
+        flat-0-simpflat-38 =w flat-41-simpflat-78
+        flat-0-simpflat-39 =w flat-41-simpflat-79
+        flat-0-simpflat-40 =w flat-41-simpflat-80
+        flat-0-simpflat-41 =w flat-41-simpflat-81
     }
     else
     {
-        flat-0-simpflat-40 =w conv-34-aval-0-simpflat-35
+        flat-0-simpflat-38 =w conv-34-aval-0-simpflat-33
+        flat-0-simpflat-39 =w unsafe_Array_create#
+                                0
+        flat-0-simpflat-40 =w unsafe_Array_create#
+                                0
         flat-0-simpflat-41 =w unsafe_Array_create#
-                                0
-        flat-0-simpflat-42 =w unsafe_Array_create#
-                                0
-        flat-0-simpflat-43 =w unsafe_Array_create#
                                 0
     }
     
-    flat-0-simpflat-76 =r flat-0-simpflat-40
-    flat-0-simpflat-77 =r flat-0-simpflat-41
-    flat-0-simpflat-78 =r flat-0-simpflat-42
-    flat-0-simpflat-79 =r flat-0-simpflat-43
-    acc-conv-34-simpflat-30 =w flat-0-simpflat-76
-    acc-conv-34-simpflat-31 =w flat-0-simpflat-77
-    acc-conv-34-simpflat-32 =w flat-0-simpflat-78
-    acc-conv-34-simpflat-33 =w flat-0-simpflat-79
+    flat-0-simpflat-83 =r flat-0-simpflat-38
+    flat-0-simpflat-84 =r flat-0-simpflat-39
+    flat-0-simpflat-85 =r flat-0-simpflat-40
+    flat-0-simpflat-86 =r flat-0-simpflat-41
+    acc-conv-34-simpflat-28 =w flat-0-simpflat-83
+    acc-conv-34-simpflat-29 =w flat-0-simpflat-84
+    acc-conv-34-simpflat-30 =w flat-0-simpflat-85
+    acc-conv-34-simpflat-31 =w flat-0-simpflat-86
 }
 
-conv-34-simpflat-81 =r acc-conv-34-simpflat-30
-conv-34-simpflat-82 =r acc-conv-34-simpflat-31
-conv-34-simpflat-83 =r acc-conv-34-simpflat-32
-conv-34-simpflat-84 =r acc-conv-34-simpflat-33
-flat-40-simpflat-86 =i ExceptNotAnError : Error
-flat-40-simpflat-87 =i unsafe_Array_create#
+conv-34-simpflat-88 =r acc-conv-34-simpflat-28
+conv-34-simpflat-89 =r acc-conv-34-simpflat-29
+conv-34-simpflat-90 =r acc-conv-34-simpflat-30
+conv-34-simpflat-91 =r acc-conv-34-simpflat-31
+flat-42-simpflat-93 =i ExceptNotAnError : Error
+flat-42-simpflat-94 =i unsafe_Array_create#
                          0 : Array Time
-flat-40-simpflat-88 =i unsafe_Array_create#
+flat-42-simpflat-95 =i unsafe_Array_create#
                          0 : Array Int
 
 if (eq#
-      conv-34-simpflat-81
+      conv-34-simpflat-88
       ExceptNotAnError)
 {
-    flat-48-simpflat-89 =i ExceptNotAnError : Error
-    flat-48-simpflat-90 =i unsafe_Array_create#
+    flat-50-simpflat-96 =i ExceptNotAnError : Error
+    flat-50-simpflat-97 =i unsafe_Array_create#
                              0 : Array Time
-    flat-48-simpflat-91 =i unsafe_Array_create#
+    flat-50-simpflat-98 =i unsafe_Array_create#
                              0 : Array Int
     
-    foreach (for_counter-flat-49 in 0 .. Array_length#
-                                           conv-34-simpflat-82)
+    foreach (for_counter-flat-51 in 0 .. Array_length#
+                                           conv-34-simpflat-89)
     {
-        flat-48-simpflat-92 =r flat-48-simpflat-89
-        flat-48-simpflat-93 =r flat-48-simpflat-90
-        flat-48-simpflat-94 =r flat-48-simpflat-91
-        simpflat-310 = unsafe_Array_index#
-                         conv-34-simpflat-82
-                         for_counter-flat-49
-        simpflat-312 = unsafe_Array_index#
-                         conv-34-simpflat-83
-                         for_counter-flat-49
-        simpflat-314 = unsafe_Array_index#
-                         conv-34-simpflat-84
-                         for_counter-flat-49
-        flat-51-simpflat-95 =i ExceptNotAnError : Error
-        flat-51-simpflat-96 =i unsafe_Array_create#
-                                 0 : Array Time
-        flat-51-simpflat-97 =i unsafe_Array_create#
-                                 0 : Array Int
+        flat-50-simpflat-99 =r flat-50-simpflat-96
+        flat-50-simpflat-100 =r flat-50-simpflat-97
+        flat-50-simpflat-101 =r flat-50-simpflat-98
+        simpflat-318 = unsafe_Array_index#
+                         conv-34-simpflat-89
+                         for_counter-flat-51
+        simpflat-320 = unsafe_Array_index#
+                         conv-34-simpflat-90
+                         for_counter-flat-51
+        simpflat-322 = unsafe_Array_index#
+                         conv-34-simpflat-91
+                         for_counter-flat-51
+        flat-53-simpflat-102 =i ExceptNotAnError : Error
+        flat-53-simpflat-103 =i unsafe_Array_create#
+                                  0 : Array Time
+        flat-53-simpflat-104 =i unsafe_Array_create#
+                                  0 : Array Int
         
         if (eq#
-              flat-48-simpflat-92
+              flat-50-simpflat-99
               ExceptNotAnError)
         {
-            simpflat-326 = Buf_read#
-                             simpflat-312
-            simpflat-328 = Buf_read#
-                             simpflat-314
-            flat-55-simpflat-98 =i ExceptNotAnError : Error
-            flat-55-simpflat-99 =i 0 : Int
+            simpflat-334 = Buf_read#
+                             simpflat-320
+            simpflat-336 = Buf_read#
+                             simpflat-322
+            flat-57-simpflat-105 =i ExceptNotAnError : Error
+            flat-57-simpflat-106 =i 0 : Int
             
-            foreach (for_counter-flat-93 in 0 .. Array_length#
-                                                   simpflat-326)
+            foreach (for_counter-flat-97 in 0 .. Array_length#
+                                                   simpflat-334)
             {
-                flat-55-simpflat-100 =r flat-55-simpflat-98
-                flat-55-simpflat-101 =r flat-55-simpflat-99
-                simpflat-333 = unsafe_Array_index#
-                                 simpflat-326
-                                 for_counter-flat-93
-                simpflat-335 = unsafe_Array_index#
-                                 simpflat-328
-                                 for_counter-flat-93
-                flat-95-simpflat-102 =i ExceptNotAnError : Error
-                flat-95-simpflat-103 =i 0 : Int
+                flat-57-simpflat-107 =r flat-57-simpflat-105
+                flat-57-simpflat-108 =r flat-57-simpflat-106
+                simpflat-341 = unsafe_Array_index#
+                                 simpflat-334
+                                 for_counter-flat-97
+                simpflat-343 = unsafe_Array_index#
+                                 simpflat-336
+                                 for_counter-flat-97
+                flat-99-simpflat-109 =i ExceptNotAnError : Error
+                flat-99-simpflat-110 =i 0 : Int
                 
                 if (eq#
-                      simpflat-333
+                      simpflat-341
                       ExceptNotAnError)
                 {
-                    flat-98-simpflat-104 =i ExceptNotAnError : Error
-                    flat-98-simpflat-105 =i 0 : Int
+                    flat-102-simpflat-111 =i ExceptNotAnError : Error
+                    flat-102-simpflat-112 =i 0 : Int
                     
                     if (eq#
-                          flat-55-simpflat-100
+                          flat-57-simpflat-107
                           ExceptNotAnError)
                     {
-                        simpflat-16 = add#
-                                        simpflat-335
-                                        flat-55-simpflat-101
-                        flat-98-simpflat-104 =w ExceptNotAnError
-                        flat-98-simpflat-105 =w simpflat-16
+                        simpflat-15 = add#
+                                        simpflat-343
+                                        flat-57-simpflat-108
+                        flat-102-simpflat-111 =w ExceptNotAnError
+                        flat-102-simpflat-112 =w simpflat-15
                     }
                     else
                     {
-                        flat-98-simpflat-104 =w flat-55-simpflat-100
-                        flat-98-simpflat-105 =w 0
+                        flat-102-simpflat-111 =w flat-57-simpflat-107
+                        flat-102-simpflat-112 =w 0
                     }
                     
-                    flat-98-simpflat-106 =r flat-98-simpflat-104
-                    flat-98-simpflat-107 =r flat-98-simpflat-105
-                    flat-95-simpflat-102 =w flat-98-simpflat-106
-                    flat-95-simpflat-103 =w flat-98-simpflat-107
+                    flat-102-simpflat-113 =r flat-102-simpflat-111
+                    flat-102-simpflat-114 =r flat-102-simpflat-112
+                    flat-99-simpflat-109 =w flat-102-simpflat-113
+                    flat-99-simpflat-110 =w flat-102-simpflat-114
                 }
                 else
                 {
-                    flat-95-simpflat-102 =w simpflat-333
-                    flat-95-simpflat-103 =w 0
+                    flat-99-simpflat-109 =w simpflat-341
+                    flat-99-simpflat-110 =w 0
                 }
                 
-                flat-95-simpflat-108 =r flat-95-simpflat-102
-                flat-95-simpflat-109 =r flat-95-simpflat-103
-                flat-55-simpflat-98 =w flat-95-simpflat-108
-                flat-55-simpflat-99 =w flat-95-simpflat-109
+                flat-99-simpflat-115 =r flat-99-simpflat-109
+                flat-99-simpflat-116 =r flat-99-simpflat-110
+                flat-57-simpflat-105 =w flat-99-simpflat-115
+                flat-57-simpflat-106 =w flat-99-simpflat-116
             }
             
-            flat-106-simpflat-110 =r flat-55-simpflat-98
-            flat-106-simpflat-111 =r flat-55-simpflat-99
-            flat-56-simpflat-112 =i ExceptNotAnError : Error
-            flat-56-simpflat-113 =i unsafe_Array_create#
+            flat-112-simpflat-117 =r flat-57-simpflat-105
+            flat-112-simpflat-118 =r flat-57-simpflat-106
+            flat-58-simpflat-119 =i ExceptNotAnError : Error
+            flat-58-simpflat-120 =i unsafe_Array_create#
                                       0 : Array Time
-            flat-56-simpflat-114 =i unsafe_Array_create#
+            flat-58-simpflat-121 =i unsafe_Array_create#
                                       0 : Array Int
             
             if (eq#
-                  flat-106-simpflat-110
+                  flat-112-simpflat-117
                   ExceptNotAnError)
             {
-                map_insert_acc_keys-flat-59 =i flat-48-simpflat-93 : Array Time
-                map_insert_acc_vals-flat-60 =i flat-48-simpflat-94 : Array Int
-                map_insert_acc_bs_found-flat-62 =i False : Bool
-                map_insert_acc_bs_index-flat-61 =i -1 : Int
-                map_insert_loc_keys-flat-63 =r map_insert_acc_keys-flat-59
-                map_insert_loc_vals-flat-64 =r map_insert_acc_vals-flat-60
-                map_insert_size-flat-68 = Array_length#
-                                            map_insert_loc_keys-flat-63
-                bs_acc_found-flat-76 =i False : Bool
-                bs_acc_mid-flat-73 =i -1 : Int
-                bs_acc_ins-flat-75 =i -1 : Int
-                bs_acc_low-flat-81 =i 0 : Int
-                bs_acc_high-flat-82 =i sub#
-                                         map_insert_size-flat-68
+                map_insert_acc_keys-flat-61 =i flat-50-simpflat-100 : Array Time
+                map_insert_acc_vals-flat-62 =i flat-50-simpflat-101 : Array Int
+                map_insert_acc_bs_found-flat-64 =i False : Bool
+                map_insert_acc_bs_index-flat-63 =i -1 : Int
+                map_insert_loc_keys-flat-65 =r map_insert_acc_keys-flat-61
+                map_insert_size-flat-72 = Array_length#
+                                            map_insert_loc_keys-flat-65
+                bs_acc_found-flat-80 =i False : Bool
+                bs_acc_mid-flat-77 =i -1 : Int
+                bs_acc_ins-flat-79 =i -1 : Int
+                bs_acc_low-flat-85 =i 0 : Int
+                bs_acc_high-flat-86 =i sub#
+                                         map_insert_size-flat-72
                                          1 : Int
-                bs_acc_end-flat-83 =i False : Bool
+                bs_acc_end-flat-87 =i False : Bool
                 
-                while (bs_acc_end-flat-83 == False)
+                while (bs_acc_end-flat-87 == False)
                 {
-                    bs_loc_low-flat-79 =r bs_acc_low-flat-81
-                    bs_loc_high-flat-80 =r bs_acc_high-flat-82
+                    bs_loc_low-flat-83 =r bs_acc_low-flat-85
+                    bs_loc_high-flat-84 =r bs_acc_high-flat-86
                     
                     if (gt#
-                          bs_loc_low-flat-79
-                          bs_loc_high-flat-80)
+                          bs_loc_low-flat-83
+                          bs_loc_high-flat-84)
                     {
-                        bs_acc_end-flat-83 =w True
-                        bs_acc_ins-flat-75 =w bs_loc_low-flat-79
+                        bs_acc_end-flat-87 =w True
+                        bs_acc_ins-flat-79 =w bs_loc_low-flat-83
                     }
                     else
                     {
-                        simpflat-19 = add#
-                                        bs_loc_low-flat-79
-                                        bs_loc_high-flat-80
-                        simpflat-20 = doubleOfInt#
+                        simpflat-18 = add#
+                                        bs_loc_low-flat-83
+                                        bs_loc_high-flat-84
+                        simpflat-19 = doubleOfInt#
+                                        simpflat-18
+                        simpflat-20 = div#
                                         simpflat-19
-                        simpflat-21 = div#
-                                        simpflat-20
                                         2.0
-                        bs_acc_mid-flat-73 =w floor#
-                                                simpflat-21
-                        bs_loc_mid-flat-77 =r bs_acc_mid-flat-73
-                        bs_loc_x-flat-78 = unsafe_Array_index#
-                                             map_insert_loc_keys-flat-63
-                                             bs_loc_mid-flat-77
+                        bs_acc_mid-flat-77 =w floor#
+                                                simpflat-20
+                        bs_loc_mid-flat-81 =r bs_acc_mid-flat-77
+                        bs_loc_x-flat-82 = unsafe_Array_index#
+                                             map_insert_loc_keys-flat-65
+                                             bs_loc_mid-flat-81
                         
                         if (eq#
-                              bs_loc_x-flat-78
-                              simpflat-310)
+                              bs_loc_x-flat-82
+                              simpflat-318)
                         {
-                            bs_acc_end-flat-83 =w True
-                            bs_acc_found-flat-76 =w True
+                            bs_acc_end-flat-87 =w True
+                            bs_acc_found-flat-80 =w True
                         }
                         else
                         {
                             
                             if (lt#
-                                  bs_loc_x-flat-78
-                                  simpflat-310)
+                                  bs_loc_x-flat-82
+                                  simpflat-318)
                             {
-                                bs_acc_low-flat-81 =w add#
-                                                        bs_loc_mid-flat-77
+                                bs_acc_low-flat-85 =w add#
+                                                        bs_loc_mid-flat-81
                                                         1
                             }
                             else
                             {
-                                bs_acc_high-flat-82 =w sub#
-                                                         bs_loc_mid-flat-77
+                                bs_acc_high-flat-86 =w sub#
+                                                         bs_loc_mid-flat-81
                                                          1
                             }
                             
@@ -853,173 +840,164 @@ if (eq#
                     
                 }
                 
-                bs_loc_found-flat-71 =r bs_acc_found-flat-76
-                bs_loc_mid-flat-72 =r bs_acc_mid-flat-73
-                bs_loc_ins-flat-74 =r bs_acc_ins-flat-75
+                bs_loc_found-flat-75 =r bs_acc_found-flat-80
+                bs_loc_mid-flat-76 =r bs_acc_mid-flat-77
+                bs_loc_ins-flat-78 =r bs_acc_ins-flat-79
                 
                 if (eq#
-                      bs_loc_found-flat-71
+                      bs_loc_found-flat-75
                       True)
                 {
-                    map_insert_acc_bs_found-flat-62 =w True
-                    map_insert_acc_bs_index-flat-61 =w bs_loc_mid-flat-72
+                    map_insert_acc_bs_found-flat-64 =w True
+                    map_insert_acc_bs_index-flat-63 =w bs_loc_mid-flat-76
                 }
                 else
                 {
-                    map_insert_acc_bs_found-flat-62 =w False
-                    map_insert_acc_bs_index-flat-61 =w bs_loc_ins-flat-74
+                    map_insert_acc_bs_found-flat-64 =w False
+                    map_insert_acc_bs_index-flat-63 =w bs_loc_ins-flat-78
                 }
                 
-                flat-107 =r map_insert_acc_bs_found-flat-62
-                flat-108 =r map_insert_acc_bs_index-flat-61
+                flat-113 =r map_insert_acc_bs_found-flat-64
+                flat-114 =r map_insert_acc_bs_index-flat-63
                 
-                if (eq# flat-107 True)
+                if (eq# flat-113 True)
                 {
-                    map_insert_acc_vals-flat-60 =r map_insert_acc_vals-flat-60
-                    map_insert_acc_vals-flat-60 =w Array_put_immutable#
-                                                     map_insert_acc_vals-flat-60
-                                                     flat-108
-                                                     flat-106-simpflat-111
+                    copy_array-flat-91 =r map_insert_acc_vals-flat-62
+                    simpflat-21 = Array_length#
+                                    copy_array-flat-91
+                    
+                    if (ne# simpflat-21 0)
+                    {
+                        map_insert_acc_vals-flat-62 =w copy_array-flat-91
+                    }
+                    
+                    map_insert_acc_vals-flat-62 =r map_insert_acc_vals-flat-62
+                    map_insert_acc_vals-flat-62 =w Array_put_mutable#
+                                                     map_insert_acc_vals-flat-62
+                                                     flat-114
+                                                     flat-112-simpflat-118
                 }
                 else
                 {
-                    copy_array-flat-86 =r map_insert_acc_keys-flat-59
+                    copy_array-flat-90 =r map_insert_acc_keys-flat-61
                     simpflat-22 = Array_length#
-                                    copy_array-flat-86
+                                    copy_array-flat-90
                     
-                    if (eq# simpflat-22 0)
+                    if (ne# simpflat-22 0)
                     {
-                        
-                    }
-                    else
-                    {
-                        simpflat-23 = unsafe_Array_index#
-                                        copy_array-flat-86
-                                        0
-                        map_insert_acc_keys-flat-59 =w Array_put_immutable#
-                                                         copy_array-flat-86
-                                                         0
-                                                         simpflat-23
+                        map_insert_acc_keys-flat-61 =w copy_array-flat-90
                     }
                     
-                    copy_array-flat-87 =r map_insert_acc_vals-flat-60
-                    simpflat-24 = Array_length#
-                                    copy_array-flat-87
+                    flat-115 =r map_insert_acc_vals-flat-62
+                    simpflat-23 = Array_length#
+                                    flat-115
                     
-                    if (eq# simpflat-24 0)
+                    if (ne# simpflat-23 0)
                     {
-                        
-                    }
-                    else
-                    {
-                        simpflat-25 = unsafe_Array_index#
-                                        copy_array-flat-87
-                                        0
-                        map_insert_acc_vals-flat-60 =w Array_put_immutable#
-                                                         copy_array-flat-87
-                                                         0
-                                                         simpflat-25
+                        map_insert_acc_vals-flat-62 =w flat-115
                     }
                     
+                    map_insert_cpy_keys-flat-67 =r map_insert_acc_keys-flat-61
+                    flat-116 =r map_insert_acc_vals-flat-62
                     
-                    foreach (for_counter-flat-88 in map_insert_size-flat-68 .. flat-108)
+                    foreach (for_counter-flat-92 in map_insert_size-flat-72 .. flat-114)
                     {
-                        update_acc-flat-89 =r map_insert_acc_keys-flat-59
-                        simpflat-26 = sub#
-                                        for_counter-flat-88
+                        update_acc-flat-93 =r map_insert_acc_keys-flat-61
+                        simpflat-24 = sub#
+                                        for_counter-flat-92
                                         1
+                        simpflat-25 = unsafe_Array_index#
+                                        map_insert_cpy_keys-flat-67
+                                        simpflat-24
+                        map_insert_acc_keys-flat-61 =w Array_put_mutable#
+                                                         update_acc-flat-93
+                                                         for_counter-flat-92
+                                                         simpflat-25
+                        update_acc-flat-94 =r map_insert_acc_vals-flat-62
                         simpflat-27 = unsafe_Array_index#
-                                        map_insert_loc_keys-flat-63
-                                        simpflat-26
-                        map_insert_acc_keys-flat-59 =w Array_put_mutable#
-                                                         update_acc-flat-89
-                                                         for_counter-flat-88
+                                        flat-116
+                                        simpflat-24
+                        map_insert_acc_vals-flat-62 =w Array_put_mutable#
+                                                         update_acc-flat-94
+                                                         for_counter-flat-92
                                                          simpflat-27
-                        update_acc-flat-90 =r map_insert_acc_vals-flat-60
-                        simpflat-29 = unsafe_Array_index#
-                                        map_insert_loc_vals-flat-64
-                                        simpflat-26
-                        map_insert_acc_vals-flat-60 =w Array_put_mutable#
-                                                         update_acc-flat-90
-                                                         for_counter-flat-88
-                                                         simpflat-29
                     }
                     
-                    map_insert_acc_keys-flat-59 =r map_insert_acc_keys-flat-59
-                    map_insert_acc_keys-flat-59 =w Array_put_mutable#
-                                                     map_insert_acc_keys-flat-59
-                                                     flat-108
-                                                     simpflat-310
-                    map_insert_acc_vals-flat-60 =r map_insert_acc_vals-flat-60
-                    map_insert_acc_vals-flat-60 =w Array_put_mutable#
-                                                     map_insert_acc_vals-flat-60
-                                                     flat-108
-                                                     flat-106-simpflat-111
+                    map_insert_acc_keys-flat-61 =r map_insert_acc_keys-flat-61
+                    map_insert_acc_keys-flat-61 =w Array_put_mutable#
+                                                     map_insert_acc_keys-flat-61
+                                                     flat-114
+                                                     simpflat-318
+                    map_insert_acc_vals-flat-62 =r map_insert_acc_vals-flat-62
+                    map_insert_acc_vals-flat-62 =w Array_put_mutable#
+                                                     map_insert_acc_vals-flat-62
+                                                     flat-114
+                                                     flat-112-simpflat-118
                 }
                 
-                flat-109 =r map_insert_acc_keys-flat-59
-                flat-110 =r map_insert_acc_vals-flat-60
-                flat-56-simpflat-112 =w ExceptNotAnError
-                flat-56-simpflat-113 =w flat-109
-                flat-56-simpflat-114 =w flat-110
+                flat-117 =r map_insert_acc_keys-flat-61
+                flat-118 =r map_insert_acc_vals-flat-62
+                flat-58-simpflat-119 =w ExceptNotAnError
+                flat-58-simpflat-120 =w flat-117
+                flat-58-simpflat-121 =w flat-118
             }
             else
             {
-                flat-56-simpflat-112 =w flat-106-simpflat-110
-                flat-56-simpflat-113 =w unsafe_Array_create#
+                flat-58-simpflat-119 =w flat-112-simpflat-117
+                flat-58-simpflat-120 =w unsafe_Array_create#
                                           0
-                flat-56-simpflat-114 =w unsafe_Array_create#
+                flat-58-simpflat-121 =w unsafe_Array_create#
                                           0
             }
             
-            flat-56-simpflat-115 =r flat-56-simpflat-112
-            flat-56-simpflat-116 =r flat-56-simpflat-113
-            flat-56-simpflat-117 =r flat-56-simpflat-114
-            flat-51-simpflat-95 =w flat-56-simpflat-115
-            flat-51-simpflat-96 =w flat-56-simpflat-116
-            flat-51-simpflat-97 =w flat-56-simpflat-117
+            flat-58-simpflat-122 =r flat-58-simpflat-119
+            flat-58-simpflat-123 =r flat-58-simpflat-120
+            flat-58-simpflat-124 =r flat-58-simpflat-121
+            flat-53-simpflat-102 =w flat-58-simpflat-122
+            flat-53-simpflat-103 =w flat-58-simpflat-123
+            flat-53-simpflat-104 =w flat-58-simpflat-124
         }
         else
         {
-            flat-51-simpflat-95 =w flat-48-simpflat-92
-            flat-51-simpflat-96 =w unsafe_Array_create#
-                                     0
-            flat-51-simpflat-97 =w unsafe_Array_create#
-                                     0
+            flat-53-simpflat-102 =w flat-50-simpflat-99
+            flat-53-simpflat-103 =w unsafe_Array_create#
+                                      0
+            flat-53-simpflat-104 =w unsafe_Array_create#
+                                      0
         }
         
-        flat-51-simpflat-118 =r flat-51-simpflat-95
-        flat-51-simpflat-119 =r flat-51-simpflat-96
-        flat-51-simpflat-120 =r flat-51-simpflat-97
-        flat-48-simpflat-89 =w flat-51-simpflat-118
-        flat-48-simpflat-90 =w flat-51-simpflat-119
-        flat-48-simpflat-91 =w flat-51-simpflat-120
+        flat-53-simpflat-125 =r flat-53-simpflat-102
+        flat-53-simpflat-126 =r flat-53-simpflat-103
+        flat-53-simpflat-127 =r flat-53-simpflat-104
+        flat-50-simpflat-96 =w flat-53-simpflat-125
+        flat-50-simpflat-97 =w flat-53-simpflat-126
+        flat-50-simpflat-98 =w flat-53-simpflat-127
     }
     
-    flat-111-simpflat-121 =r flat-48-simpflat-89
-    flat-111-simpflat-122 =r flat-48-simpflat-90
-    flat-111-simpflat-123 =r flat-48-simpflat-91
-    flat-40-simpflat-86 =w flat-111-simpflat-121
-    flat-40-simpflat-87 =w flat-111-simpflat-122
-    flat-40-simpflat-88 =w flat-111-simpflat-123
+    flat-119-simpflat-128 =r flat-50-simpflat-96
+    flat-119-simpflat-129 =r flat-50-simpflat-97
+    flat-119-simpflat-130 =r flat-50-simpflat-98
+    flat-42-simpflat-93 =w flat-119-simpflat-128
+    flat-42-simpflat-94 =w flat-119-simpflat-129
+    flat-42-simpflat-95 =w flat-119-simpflat-130
 }
 else
 {
-    flat-40-simpflat-86 =w conv-34-simpflat-81
-    flat-40-simpflat-87 =w unsafe_Array_create#
+    flat-42-simpflat-93 =w conv-34-simpflat-88
+    flat-42-simpflat-94 =w unsafe_Array_create#
                              0
-    flat-40-simpflat-88 =w unsafe_Array_create#
+    flat-42-simpflat-95 =w unsafe_Array_create#
                              0
 }
 
-flat-40-simpflat-124 =r flat-40-simpflat-86
-flat-40-simpflat-125 =r flat-40-simpflat-87
-flat-40-simpflat-126 =r flat-40-simpflat-88
+flat-42-simpflat-131 =r flat-42-simpflat-93
+flat-42-simpflat-132 =r flat-42-simpflat-94
+flat-42-simpflat-133 =r flat-42-simpflat-95
 
 output repl:output : Sum Error (Map Time Int) =
-    flat-40-simpflat-124 : Error
-  , flat-40-simpflat-125 : Array Time
-  , flat-40-simpflat-126 : Array Int
+    flat-42-simpflat-131 : Error
+  , flat-42-simpflat-132 : Array Time
+  , flat-42-simpflat-133 : Array Int
 
 Flattened Avalanche (simplified), typechecked
 ---------------------------------------------
@@ -1029,102 +1007,100 @@ conv-2 : Time =
 conv-3 : Int =
   MAX_MAP_SIZE
 
-acc-conv-34-simpflat-30 =i ExceptNotAnError : Error
-acc-conv-34-simpflat-31 =i unsafe_Array_create#
+acc-conv-34-simpflat-28 =i ExceptNotAnError : Error
+acc-conv-34-simpflat-29 =i unsafe_Array_create#
                              0 : Array Time
-acc-conv-34-simpflat-32 =i unsafe_Array_create#
+acc-conv-34-simpflat-30 =i unsafe_Array_create#
                              0 : Array (Buf 2 Error)
-acc-conv-34-simpflat-33 =i unsafe_Array_create#
+acc-conv-34-simpflat-31 =i unsafe_Array_create#
                              0 : Array (Buf 2 Int)
 
 for_facts conv-1 : Time
-        , conv-0-simpflat-127 : Error
-        , conv-0-simpflat-128 : Int
-        , conv-0-simpflat-129 : Time {
+        , conv-0-simpflat-134 : Error
+        , conv-0-simpflat-135 : Int
+        , conv-0-simpflat-136 : Time {
+    conv-34-aval-0-simpflat-33 =r acc-conv-34-simpflat-28
+    conv-34-aval-0-simpflat-34 =r acc-conv-34-simpflat-29
     conv-34-aval-0-simpflat-35 =r acc-conv-34-simpflat-30
     conv-34-aval-0-simpflat-36 =r acc-conv-34-simpflat-31
-    conv-34-aval-0-simpflat-37 =r acc-conv-34-simpflat-32
-    conv-34-aval-0-simpflat-38 =r acc-conv-34-simpflat-33
-    flat-0-simpflat-40 =i ExceptNotAnError : Error
-    flat-0-simpflat-41 =i unsafe_Array_create#
+    flat-0-simpflat-38 =i ExceptNotAnError : Error
+    flat-0-simpflat-39 =i unsafe_Array_create#
                             0 : Array Time
-    flat-0-simpflat-42 =i unsafe_Array_create#
+    flat-0-simpflat-40 =i unsafe_Array_create#
                             0 : Array (Buf 2 Error)
-    flat-0-simpflat-43 =i unsafe_Array_create#
+    flat-0-simpflat-41 =i unsafe_Array_create#
                             0 : Array (Buf 2 Int)
     
     if (eq#
-          conv-34-aval-0-simpflat-35
+          conv-34-aval-0-simpflat-33
           ExceptNotAnError)
     {
-        map_insert_acc_keys-flat-3 =i conv-34-aval-0-simpflat-36 : Array Time
-        map_insert_acc_vals-flat-4-simpflat-45 =i conv-34-aval-0-simpflat-37 : Array (Buf 2 Error)
-        map_insert_acc_vals-flat-4-simpflat-46 =i conv-34-aval-0-simpflat-38 : Array (Buf 2 Int)
+        map_insert_acc_keys-flat-3 =i conv-34-aval-0-simpflat-34 : Array Time
+        map_insert_acc_vals-flat-4-simpflat-43 =i conv-34-aval-0-simpflat-35 : Array (Buf 2 Error)
+        map_insert_acc_vals-flat-4-simpflat-44 =i conv-34-aval-0-simpflat-36 : Array (Buf 2 Int)
         map_insert_acc_bs_found-flat-6 =i False : Bool
         map_insert_acc_bs_index-flat-5 =i -1 : Int
         map_insert_loc_keys-flat-7 =r map_insert_acc_keys-flat-3
-        map_insert_loc_vals-flat-8-simpflat-48 =r map_insert_acc_vals-flat-4-simpflat-45
-        map_insert_loc_vals-flat-8-simpflat-49 =r map_insert_acc_vals-flat-4-simpflat-46
-        map_insert_size-flat-12 = Array_length#
+        map_insert_size-flat-14 = Array_length#
                                     map_insert_loc_keys-flat-7
-        bs_acc_found-flat-20 =i False : Bool
-        bs_acc_mid-flat-17 =i -1 : Int
-        bs_acc_ins-flat-19 =i -1 : Int
-        bs_acc_low-flat-25 =i 0 : Int
-        bs_acc_high-flat-26 =i sub#
-                                 map_insert_size-flat-12
+        bs_acc_found-flat-22 =i False : Bool
+        bs_acc_mid-flat-19 =i -1 : Int
+        bs_acc_ins-flat-21 =i -1 : Int
+        bs_acc_low-flat-27 =i 0 : Int
+        bs_acc_high-flat-28 =i sub#
+                                 map_insert_size-flat-14
                                  1 : Int
-        bs_acc_end-flat-27 =i False : Bool
+        bs_acc_end-flat-29 =i False : Bool
         
-        while (bs_acc_end-flat-27 == False)
+        while (bs_acc_end-flat-29 == False)
         {
-            bs_loc_low-flat-23 =r bs_acc_low-flat-25
-            bs_loc_high-flat-24 =r bs_acc_high-flat-26
+            bs_loc_low-flat-25 =r bs_acc_low-flat-27
+            bs_loc_high-flat-26 =r bs_acc_high-flat-28
             
             if (gt#
-                  bs_loc_low-flat-23
-                  bs_loc_high-flat-24)
+                  bs_loc_low-flat-25
+                  bs_loc_high-flat-26)
             {
-                bs_acc_end-flat-27 =w True
-                bs_acc_ins-flat-19 =w bs_loc_low-flat-23
+                bs_acc_end-flat-29 =w True
+                bs_acc_ins-flat-21 =w bs_loc_low-flat-25
             }
             else
             {
                 simpflat-1 = add#
-                               bs_loc_low-flat-23
-                               bs_loc_high-flat-24
+                               bs_loc_low-flat-25
+                               bs_loc_high-flat-26
                 simpflat-2 = doubleOfInt#
                                simpflat-1
                 simpflat-3 = div# simpflat-2 2.0
-                bs_acc_mid-flat-17 =w floor#
+                bs_acc_mid-flat-19 =w floor#
                                         simpflat-3
-                bs_loc_mid-flat-21 =r bs_acc_mid-flat-17
-                bs_loc_x-flat-22 = unsafe_Array_index#
+                bs_loc_mid-flat-23 =r bs_acc_mid-flat-19
+                bs_loc_x-flat-24 = unsafe_Array_index#
                                      map_insert_loc_keys-flat-7
-                                     bs_loc_mid-flat-21
+                                     bs_loc_mid-flat-23
                 
                 if (eq#
-                      bs_loc_x-flat-22
-                      conv-0-simpflat-129)
+                      bs_loc_x-flat-24
+                      conv-0-simpflat-136)
                 {
-                    bs_acc_end-flat-27 =w True
-                    bs_acc_found-flat-20 =w True
+                    bs_acc_end-flat-29 =w True
+                    bs_acc_found-flat-22 =w True
                 }
                 else
                 {
                     
                     if (lt#
-                          bs_loc_x-flat-22
-                          conv-0-simpflat-129)
+                          bs_loc_x-flat-24
+                          conv-0-simpflat-136)
                     {
-                        bs_acc_low-flat-25 =w add#
-                                                bs_loc_mid-flat-21
+                        bs_acc_low-flat-27 =w add#
+                                                bs_loc_mid-flat-23
                                                 1
                     }
                     else
                     {
-                        bs_acc_high-flat-26 =w sub#
-                                                 bs_loc_mid-flat-21
+                        bs_acc_high-flat-28 =w sub#
+                                                 bs_loc_mid-flat-23
                                                  1
                     }
                     
@@ -1134,403 +1110,392 @@ for_facts conv-1 : Time
             
         }
         
-        bs_loc_found-flat-15 =r bs_acc_found-flat-20
-        bs_loc_mid-flat-16 =r bs_acc_mid-flat-17
-        bs_loc_ins-flat-18 =r bs_acc_ins-flat-19
+        bs_loc_found-flat-17 =r bs_acc_found-flat-22
+        bs_loc_mid-flat-18 =r bs_acc_mid-flat-19
+        bs_loc_ins-flat-20 =r bs_acc_ins-flat-21
         
         if (eq#
-              bs_loc_found-flat-15
+              bs_loc_found-flat-17
               True)
         {
             map_insert_acc_bs_found-flat-6 =w True
-            map_insert_acc_bs_index-flat-5 =w bs_loc_mid-flat-16
+            map_insert_acc_bs_index-flat-5 =w bs_loc_mid-flat-18
         }
         else
         {
             map_insert_acc_bs_found-flat-6 =w False
-            map_insert_acc_bs_index-flat-5 =w bs_loc_ins-flat-18
+            map_insert_acc_bs_index-flat-5 =w bs_loc_ins-flat-20
         }
         
-        flat-101 =r map_insert_acc_bs_found-flat-6
-        flat-102 =r map_insert_acc_bs_index-flat-5
+        flat-105 =r map_insert_acc_bs_found-flat-6
+        flat-106 =r map_insert_acc_bs_index-flat-5
         
-        if (eq# flat-101 True)
+        if (eq# flat-105 True)
         {
-            simpflat-240 = unsafe_Array_index#
-                             map_insert_loc_vals-flat-8-simpflat-48
-                             flat-102
-            simpflat-242 = unsafe_Array_index#
-                             map_insert_loc_vals-flat-8-simpflat-49
-                             flat-102
-            simpflat-247 = Buf_push#
-                             simpflat-240
-                             conv-0-simpflat-127
-            simpflat-250 = Buf_push#
-                             simpflat-242
-                             conv-0-simpflat-128
-            map_insert_acc_vals-flat-4-simpflat-45 =r map_insert_acc_vals-flat-4-simpflat-45
-            map_insert_acc_vals-flat-4-simpflat-45 =w Array_put_immutable#
-                                                        map_insert_acc_vals-flat-4-simpflat-45
-                                                        flat-102
-                                                        simpflat-247
-            map_insert_acc_vals-flat-4-simpflat-46 =r map_insert_acc_vals-flat-4-simpflat-46
-            map_insert_acc_vals-flat-4-simpflat-46 =w Array_put_immutable#
-                                                        map_insert_acc_vals-flat-4-simpflat-46
-                                                        flat-102
-                                                        simpflat-250
+            copy_array-flat-34-simpflat-49 =r map_insert_acc_vals-flat-4-simpflat-43
+            copy_array-flat-34-simpflat-50 =r map_insert_acc_vals-flat-4-simpflat-44
+            simpflat-4 = Array_length#
+                           copy_array-flat-34-simpflat-49
+            
+            if (ne# simpflat-4 0)
+            {
+                map_insert_acc_vals-flat-4-simpflat-43 =w copy_array-flat-34-simpflat-49
+                map_insert_acc_vals-flat-4-simpflat-44 =w copy_array-flat-34-simpflat-50
+            }
+            
+            map_insert_cpy_vals-flat-10-simpflat-52 =r map_insert_acc_vals-flat-4-simpflat-43
+            map_insert_cpy_vals-flat-10-simpflat-53 =r map_insert_acc_vals-flat-4-simpflat-44
+            simpflat-257 = unsafe_Array_index#
+                             map_insert_cpy_vals-flat-10-simpflat-52
+                             flat-106
+            simpflat-259 = unsafe_Array_index#
+                             map_insert_cpy_vals-flat-10-simpflat-53
+                             flat-106
+            simpflat-264 = Buf_push#
+                             simpflat-257
+                             conv-0-simpflat-134
+            simpflat-267 = Buf_push#
+                             simpflat-259
+                             conv-0-simpflat-135
+            map_insert_acc_vals-flat-4-simpflat-43 =r map_insert_acc_vals-flat-4-simpflat-43
+            map_insert_acc_vals-flat-4-simpflat-43 =w Array_put_mutable#
+                                                        map_insert_acc_vals-flat-4-simpflat-43
+                                                        flat-106
+                                                        simpflat-264
+            map_insert_acc_vals-flat-4-simpflat-44 =r map_insert_acc_vals-flat-4-simpflat-44
+            map_insert_acc_vals-flat-4-simpflat-44 =w Array_put_mutable#
+                                                        map_insert_acc_vals-flat-4-simpflat-44
+                                                        flat-106
+                                                        simpflat-267
         }
         else
         {
-            copy_array-flat-31 =r map_insert_acc_keys-flat-3
-            simpflat-4 = Array_length#
-                           copy_array-flat-31
+            copy_array-flat-33 =r map_insert_acc_keys-flat-3
+            simpflat-5 = Array_length#
+                           copy_array-flat-33
             
-            if (eq# simpflat-4 0)
+            if (ne# simpflat-5 0)
             {
-                
-            }
-            else
-            {
-                simpflat-5 = unsafe_Array_index#
-                               copy_array-flat-31
-                               0
-                map_insert_acc_keys-flat-3 =w Array_put_immutable#
-                                                copy_array-flat-31
-                                                0
-                                                simpflat-5
+                map_insert_acc_keys-flat-3 =w copy_array-flat-33
             }
             
-            copy_array-flat-32-simpflat-54 =r map_insert_acc_vals-flat-4-simpflat-45
-            copy_array-flat-32-simpflat-55 =r map_insert_acc_vals-flat-4-simpflat-46
+            flat-107-simpflat-58 =r map_insert_acc_vals-flat-4-simpflat-43
+            flat-107-simpflat-59 =r map_insert_acc_vals-flat-4-simpflat-44
             simpflat-6 = Array_length#
-                           copy_array-flat-32-simpflat-54
+                           flat-107-simpflat-58
             
-            if (eq# simpflat-6 0)
+            if (ne# simpflat-6 0)
             {
-                
-            }
-            else
-            {
-                simpflat-262 = unsafe_Array_index#
-                                 copy_array-flat-32-simpflat-54
-                                 0
-                simpflat-264 = unsafe_Array_index#
-                                 copy_array-flat-32-simpflat-55
-                                 0
-                map_insert_acc_vals-flat-4-simpflat-45 =w Array_put_immutable#
-                                                            copy_array-flat-32-simpflat-54
-                                                            0
-                                                            simpflat-262
-                map_insert_acc_vals-flat-4-simpflat-46 =w Array_put_immutable#
-                                                            copy_array-flat-32-simpflat-55
-                                                            0
-                                                            simpflat-264
+                map_insert_acc_vals-flat-4-simpflat-43 =w flat-107-simpflat-58
+                map_insert_acc_vals-flat-4-simpflat-44 =w flat-107-simpflat-59
             }
             
+            map_insert_cpy_keys-flat-9 =r map_insert_acc_keys-flat-3
+            flat-108-simpflat-61 =r map_insert_acc_vals-flat-4-simpflat-43
+            flat-108-simpflat-62 =r map_insert_acc_vals-flat-4-simpflat-44
             
-            foreach (for_counter-flat-33 in map_insert_size-flat-12 .. flat-102)
+            foreach (for_counter-flat-35 in map_insert_size-flat-14 .. flat-106)
             {
-                update_acc-flat-34 =r map_insert_acc_keys-flat-3
-                simpflat-8 = sub#
-                               for_counter-flat-33
+                update_acc-flat-36 =r map_insert_acc_keys-flat-3
+                simpflat-7 = sub#
+                               for_counter-flat-35
                                1
-                simpflat-9 = unsafe_Array_index#
-                               map_insert_loc_keys-flat-7
-                               simpflat-8
+                simpflat-8 = unsafe_Array_index#
+                               map_insert_cpy_keys-flat-9
+                               simpflat-7
                 map_insert_acc_keys-flat-3 =w Array_put_mutable#
-                                                update_acc-flat-34
-                                                for_counter-flat-33
-                                                simpflat-9
-                update_acc-flat-35-simpflat-57 =r map_insert_acc_vals-flat-4-simpflat-45
-                update_acc-flat-35-simpflat-58 =r map_insert_acc_vals-flat-4-simpflat-46
-                simpflat-274 = unsafe_Array_index#
-                                 map_insert_loc_vals-flat-8-simpflat-48
-                                 simpflat-8
-                simpflat-276 = unsafe_Array_index#
-                                 map_insert_loc_vals-flat-8-simpflat-49
-                                 simpflat-8
-                map_insert_acc_vals-flat-4-simpflat-45 =w Array_put_mutable#
-                                                            update_acc-flat-35-simpflat-57
-                                                            for_counter-flat-33
-                                                            simpflat-274
-                map_insert_acc_vals-flat-4-simpflat-46 =w Array_put_mutable#
-                                                            update_acc-flat-35-simpflat-58
-                                                            for_counter-flat-33
-                                                            simpflat-276
+                                                update_acc-flat-36
+                                                for_counter-flat-35
+                                                simpflat-8
+                update_acc-flat-37-simpflat-64 =r map_insert_acc_vals-flat-4-simpflat-43
+                update_acc-flat-37-simpflat-65 =r map_insert_acc_vals-flat-4-simpflat-44
+                simpflat-282 = unsafe_Array_index#
+                                 flat-108-simpflat-61
+                                 simpflat-7
+                simpflat-284 = unsafe_Array_index#
+                                 flat-108-simpflat-62
+                                 simpflat-7
+                map_insert_acc_vals-flat-4-simpflat-43 =w Array_put_mutable#
+                                                            update_acc-flat-37-simpflat-64
+                                                            for_counter-flat-35
+                                                            simpflat-282
+                map_insert_acc_vals-flat-4-simpflat-44 =w Array_put_mutable#
+                                                            update_acc-flat-37-simpflat-65
+                                                            for_counter-flat-35
+                                                            simpflat-284
             }
             
             map_insert_acc_keys-flat-3 =r map_insert_acc_keys-flat-3
             map_insert_acc_keys-flat-3 =w Array_put_mutable#
                                             map_insert_acc_keys-flat-3
-                                            flat-102
-                                            conv-0-simpflat-129
-            simpflat-351 = Buf_make# ()
-            simpflat-286 = Buf_push#
-                             simpflat-351
-                             conv-0-simpflat-127
-            simpflat-352 = Buf_make# ()
-            simpflat-288 = Buf_push#
-                             simpflat-352
-                             conv-0-simpflat-128
-            map_insert_acc_vals-flat-4-simpflat-45 =r map_insert_acc_vals-flat-4-simpflat-45
-            map_insert_acc_vals-flat-4-simpflat-45 =w Array_put_mutable#
-                                                        map_insert_acc_vals-flat-4-simpflat-45
-                                                        flat-102
-                                                        simpflat-286
-            map_insert_acc_vals-flat-4-simpflat-46 =r map_insert_acc_vals-flat-4-simpflat-46
-            map_insert_acc_vals-flat-4-simpflat-46 =w Array_put_mutable#
-                                                        map_insert_acc_vals-flat-4-simpflat-46
-                                                        flat-102
-                                                        simpflat-288
+                                            flat-106
+                                            conv-0-simpflat-136
+            simpflat-359 = Buf_make# ()
+            simpflat-294 = Buf_push#
+                             simpflat-359
+                             conv-0-simpflat-134
+            simpflat-360 = Buf_make# ()
+            simpflat-296 = Buf_push#
+                             simpflat-360
+                             conv-0-simpflat-135
+            map_insert_acc_vals-flat-4-simpflat-43 =r map_insert_acc_vals-flat-4-simpflat-43
+            map_insert_acc_vals-flat-4-simpflat-43 =w Array_put_mutable#
+                                                        map_insert_acc_vals-flat-4-simpflat-43
+                                                        flat-106
+                                                        simpflat-294
+            map_insert_acc_vals-flat-4-simpflat-44 =r map_insert_acc_vals-flat-4-simpflat-44
+            map_insert_acc_vals-flat-4-simpflat-44 =w Array_put_mutable#
+                                                        map_insert_acc_vals-flat-4-simpflat-44
+                                                        flat-106
+                                                        simpflat-296
         }
         
-        flat-103 =r map_insert_acc_keys-flat-3
-        flat-104-simpflat-63 =r map_insert_acc_vals-flat-4-simpflat-45
-        flat-104-simpflat-64 =r map_insert_acc_vals-flat-4-simpflat-46
-        flat-39-simpflat-66 =i ExceptNotAnError : Error
-        flat-39-simpflat-67 =i unsafe_Array_create#
+        flat-109 =r map_insert_acc_keys-flat-3
+        flat-110-simpflat-70 =r map_insert_acc_vals-flat-4-simpflat-43
+        flat-110-simpflat-71 =r map_insert_acc_vals-flat-4-simpflat-44
+        flat-41-simpflat-73 =i ExceptNotAnError : Error
+        flat-41-simpflat-74 =i unsafe_Array_create#
                                  0 : Array Time
-        flat-39-simpflat-68 =i unsafe_Array_create#
+        flat-41-simpflat-75 =i unsafe_Array_create#
                                  0 : Array (Buf 2 Error)
-        flat-39-simpflat-69 =i unsafe_Array_create#
+        flat-41-simpflat-76 =i unsafe_Array_create#
                                  0 : Array (Buf 2 Int)
-        simpflat-13 = Array_length#
-                        flat-103
+        simpflat-12 = Array_length#
+                        flat-109
         
-        if (lt# simpflat-13 conv-3)
+        if (lt# simpflat-12 conv-3)
         {
-            flat-39-simpflat-66 =w ExceptNotAnError
-            flat-39-simpflat-67 =w flat-103
-            flat-39-simpflat-68 =w flat-104-simpflat-63
-            flat-39-simpflat-69 =w flat-104-simpflat-64
+            flat-41-simpflat-73 =w ExceptNotAnError
+            flat-41-simpflat-74 =w flat-109
+            flat-41-simpflat-75 =w flat-110-simpflat-70
+            flat-41-simpflat-76 =w flat-110-simpflat-71
         }
         else
         {
-            flat-39-simpflat-66 =w ExceptCannotCompute
-            flat-39-simpflat-67 =w unsafe_Array_create#
+            flat-41-simpflat-73 =w ExceptCannotCompute
+            flat-41-simpflat-74 =w unsafe_Array_create#
                                      0
-            flat-39-simpflat-68 =w unsafe_Array_create#
+            flat-41-simpflat-75 =w unsafe_Array_create#
                                      0
-            flat-39-simpflat-69 =w unsafe_Array_create#
+            flat-41-simpflat-76 =w unsafe_Array_create#
                                      0
         }
         
-        flat-39-simpflat-71 =r flat-39-simpflat-66
-        flat-39-simpflat-72 =r flat-39-simpflat-67
-        flat-39-simpflat-73 =r flat-39-simpflat-68
-        flat-39-simpflat-74 =r flat-39-simpflat-69
-        flat-0-simpflat-40 =w flat-39-simpflat-71
-        flat-0-simpflat-41 =w flat-39-simpflat-72
-        flat-0-simpflat-42 =w flat-39-simpflat-73
-        flat-0-simpflat-43 =w flat-39-simpflat-74
+        flat-41-simpflat-78 =r flat-41-simpflat-73
+        flat-41-simpflat-79 =r flat-41-simpflat-74
+        flat-41-simpflat-80 =r flat-41-simpflat-75
+        flat-41-simpflat-81 =r flat-41-simpflat-76
+        flat-0-simpflat-38 =w flat-41-simpflat-78
+        flat-0-simpflat-39 =w flat-41-simpflat-79
+        flat-0-simpflat-40 =w flat-41-simpflat-80
+        flat-0-simpflat-41 =w flat-41-simpflat-81
     }
     else
     {
-        flat-0-simpflat-40 =w conv-34-aval-0-simpflat-35
+        flat-0-simpflat-38 =w conv-34-aval-0-simpflat-33
+        flat-0-simpflat-39 =w unsafe_Array_create#
+                                0
+        flat-0-simpflat-40 =w unsafe_Array_create#
+                                0
         flat-0-simpflat-41 =w unsafe_Array_create#
-                                0
-        flat-0-simpflat-42 =w unsafe_Array_create#
-                                0
-        flat-0-simpflat-43 =w unsafe_Array_create#
                                 0
     }
     
-    flat-0-simpflat-76 =r flat-0-simpflat-40
-    flat-0-simpflat-77 =r flat-0-simpflat-41
-    flat-0-simpflat-78 =r flat-0-simpflat-42
-    flat-0-simpflat-79 =r flat-0-simpflat-43
-    acc-conv-34-simpflat-30 =w flat-0-simpflat-76
-    acc-conv-34-simpflat-31 =w flat-0-simpflat-77
-    acc-conv-34-simpflat-32 =w flat-0-simpflat-78
-    acc-conv-34-simpflat-33 =w flat-0-simpflat-79
+    flat-0-simpflat-83 =r flat-0-simpflat-38
+    flat-0-simpflat-84 =r flat-0-simpflat-39
+    flat-0-simpflat-85 =r flat-0-simpflat-40
+    flat-0-simpflat-86 =r flat-0-simpflat-41
+    acc-conv-34-simpflat-28 =w flat-0-simpflat-83
+    acc-conv-34-simpflat-29 =w flat-0-simpflat-84
+    acc-conv-34-simpflat-30 =w flat-0-simpflat-85
+    acc-conv-34-simpflat-31 =w flat-0-simpflat-86
 }
 
-conv-34-simpflat-81 =r acc-conv-34-simpflat-30
-conv-34-simpflat-82 =r acc-conv-34-simpflat-31
-conv-34-simpflat-83 =r acc-conv-34-simpflat-32
-conv-34-simpflat-84 =r acc-conv-34-simpflat-33
-flat-40-simpflat-86 =i ExceptNotAnError : Error
-flat-40-simpflat-87 =i unsafe_Array_create#
+conv-34-simpflat-88 =r acc-conv-34-simpflat-28
+conv-34-simpflat-89 =r acc-conv-34-simpflat-29
+conv-34-simpflat-90 =r acc-conv-34-simpflat-30
+conv-34-simpflat-91 =r acc-conv-34-simpflat-31
+flat-42-simpflat-93 =i ExceptNotAnError : Error
+flat-42-simpflat-94 =i unsafe_Array_create#
                          0 : Array Time
-flat-40-simpflat-88 =i unsafe_Array_create#
+flat-42-simpflat-95 =i unsafe_Array_create#
                          0 : Array Int
 
 if (eq#
-      conv-34-simpflat-81
+      conv-34-simpflat-88
       ExceptNotAnError)
 {
-    flat-48-simpflat-89 =i ExceptNotAnError : Error
-    flat-48-simpflat-90 =i unsafe_Array_create#
+    flat-50-simpflat-96 =i ExceptNotAnError : Error
+    flat-50-simpflat-97 =i unsafe_Array_create#
                              0 : Array Time
-    flat-48-simpflat-91 =i unsafe_Array_create#
+    flat-50-simpflat-98 =i unsafe_Array_create#
                              0 : Array Int
     
-    foreach (for_counter-flat-49 in 0 .. Array_length#
-                                           conv-34-simpflat-82)
+    foreach (for_counter-flat-51 in 0 .. Array_length#
+                                           conv-34-simpflat-89)
     {
-        flat-48-simpflat-92 =r flat-48-simpflat-89
-        flat-48-simpflat-93 =r flat-48-simpflat-90
-        flat-48-simpflat-94 =r flat-48-simpflat-91
-        simpflat-310 = unsafe_Array_index#
-                         conv-34-simpflat-82
-                         for_counter-flat-49
-        simpflat-312 = unsafe_Array_index#
-                         conv-34-simpflat-83
-                         for_counter-flat-49
-        simpflat-314 = unsafe_Array_index#
-                         conv-34-simpflat-84
-                         for_counter-flat-49
-        flat-51-simpflat-95 =i ExceptNotAnError : Error
-        flat-51-simpflat-96 =i unsafe_Array_create#
-                                 0 : Array Time
-        flat-51-simpflat-97 =i unsafe_Array_create#
-                                 0 : Array Int
+        flat-50-simpflat-99 =r flat-50-simpflat-96
+        flat-50-simpflat-100 =r flat-50-simpflat-97
+        flat-50-simpflat-101 =r flat-50-simpflat-98
+        simpflat-318 = unsafe_Array_index#
+                         conv-34-simpflat-89
+                         for_counter-flat-51
+        simpflat-320 = unsafe_Array_index#
+                         conv-34-simpflat-90
+                         for_counter-flat-51
+        simpflat-322 = unsafe_Array_index#
+                         conv-34-simpflat-91
+                         for_counter-flat-51
+        flat-53-simpflat-102 =i ExceptNotAnError : Error
+        flat-53-simpflat-103 =i unsafe_Array_create#
+                                  0 : Array Time
+        flat-53-simpflat-104 =i unsafe_Array_create#
+                                  0 : Array Int
         
         if (eq#
-              flat-48-simpflat-92
+              flat-50-simpflat-99
               ExceptNotAnError)
         {
-            simpflat-326 = Buf_read#
-                             simpflat-312
-            simpflat-328 = Buf_read#
-                             simpflat-314
-            flat-55-simpflat-98 =i ExceptNotAnError : Error
-            flat-55-simpflat-99 =i 0 : Int
+            simpflat-334 = Buf_read#
+                             simpflat-320
+            simpflat-336 = Buf_read#
+                             simpflat-322
+            flat-57-simpflat-105 =i ExceptNotAnError : Error
+            flat-57-simpflat-106 =i 0 : Int
             
-            foreach (for_counter-flat-93 in 0 .. Array_length#
-                                                   simpflat-326)
+            foreach (for_counter-flat-97 in 0 .. Array_length#
+                                                   simpflat-334)
             {
-                flat-55-simpflat-100 =r flat-55-simpflat-98
-                flat-55-simpflat-101 =r flat-55-simpflat-99
-                simpflat-333 = unsafe_Array_index#
-                                 simpflat-326
-                                 for_counter-flat-93
-                simpflat-335 = unsafe_Array_index#
-                                 simpflat-328
-                                 for_counter-flat-93
-                flat-95-simpflat-102 =i ExceptNotAnError : Error
-                flat-95-simpflat-103 =i 0 : Int
+                flat-57-simpflat-107 =r flat-57-simpflat-105
+                flat-57-simpflat-108 =r flat-57-simpflat-106
+                simpflat-341 = unsafe_Array_index#
+                                 simpflat-334
+                                 for_counter-flat-97
+                simpflat-343 = unsafe_Array_index#
+                                 simpflat-336
+                                 for_counter-flat-97
+                flat-99-simpflat-109 =i ExceptNotAnError : Error
+                flat-99-simpflat-110 =i 0 : Int
                 
                 if (eq#
-                      simpflat-333
+                      simpflat-341
                       ExceptNotAnError)
                 {
-                    flat-98-simpflat-104 =i ExceptNotAnError : Error
-                    flat-98-simpflat-105 =i 0 : Int
+                    flat-102-simpflat-111 =i ExceptNotAnError : Error
+                    flat-102-simpflat-112 =i 0 : Int
                     
                     if (eq#
-                          flat-55-simpflat-100
+                          flat-57-simpflat-107
                           ExceptNotAnError)
                     {
-                        simpflat-16 = add#
-                                        simpflat-335
-                                        flat-55-simpflat-101
-                        flat-98-simpflat-104 =w ExceptNotAnError
-                        flat-98-simpflat-105 =w simpflat-16
+                        simpflat-15 = add#
+                                        simpflat-343
+                                        flat-57-simpflat-108
+                        flat-102-simpflat-111 =w ExceptNotAnError
+                        flat-102-simpflat-112 =w simpflat-15
                     }
                     else
                     {
-                        flat-98-simpflat-104 =w flat-55-simpflat-100
-                        flat-98-simpflat-105 =w 0
+                        flat-102-simpflat-111 =w flat-57-simpflat-107
+                        flat-102-simpflat-112 =w 0
                     }
                     
-                    flat-98-simpflat-106 =r flat-98-simpflat-104
-                    flat-98-simpflat-107 =r flat-98-simpflat-105
-                    flat-95-simpflat-102 =w flat-98-simpflat-106
-                    flat-95-simpflat-103 =w flat-98-simpflat-107
+                    flat-102-simpflat-113 =r flat-102-simpflat-111
+                    flat-102-simpflat-114 =r flat-102-simpflat-112
+                    flat-99-simpflat-109 =w flat-102-simpflat-113
+                    flat-99-simpflat-110 =w flat-102-simpflat-114
                 }
                 else
                 {
-                    flat-95-simpflat-102 =w simpflat-333
-                    flat-95-simpflat-103 =w 0
+                    flat-99-simpflat-109 =w simpflat-341
+                    flat-99-simpflat-110 =w 0
                 }
                 
-                flat-95-simpflat-108 =r flat-95-simpflat-102
-                flat-95-simpflat-109 =r flat-95-simpflat-103
-                flat-55-simpflat-98 =w flat-95-simpflat-108
-                flat-55-simpflat-99 =w flat-95-simpflat-109
+                flat-99-simpflat-115 =r flat-99-simpflat-109
+                flat-99-simpflat-116 =r flat-99-simpflat-110
+                flat-57-simpflat-105 =w flat-99-simpflat-115
+                flat-57-simpflat-106 =w flat-99-simpflat-116
             }
             
-            flat-106-simpflat-110 =r flat-55-simpflat-98
-            flat-106-simpflat-111 =r flat-55-simpflat-99
-            flat-56-simpflat-112 =i ExceptNotAnError : Error
-            flat-56-simpflat-113 =i unsafe_Array_create#
+            flat-112-simpflat-117 =r flat-57-simpflat-105
+            flat-112-simpflat-118 =r flat-57-simpflat-106
+            flat-58-simpflat-119 =i ExceptNotAnError : Error
+            flat-58-simpflat-120 =i unsafe_Array_create#
                                       0 : Array Time
-            flat-56-simpflat-114 =i unsafe_Array_create#
+            flat-58-simpflat-121 =i unsafe_Array_create#
                                       0 : Array Int
             
             if (eq#
-                  flat-106-simpflat-110
+                  flat-112-simpflat-117
                   ExceptNotAnError)
             {
-                map_insert_acc_keys-flat-59 =i flat-48-simpflat-93 : Array Time
-                map_insert_acc_vals-flat-60 =i flat-48-simpflat-94 : Array Int
-                map_insert_acc_bs_found-flat-62 =i False : Bool
-                map_insert_acc_bs_index-flat-61 =i -1 : Int
-                map_insert_loc_keys-flat-63 =r map_insert_acc_keys-flat-59
-                map_insert_loc_vals-flat-64 =r map_insert_acc_vals-flat-60
-                map_insert_size-flat-68 = Array_length#
-                                            map_insert_loc_keys-flat-63
-                bs_acc_found-flat-76 =i False : Bool
-                bs_acc_mid-flat-73 =i -1 : Int
-                bs_acc_ins-flat-75 =i -1 : Int
-                bs_acc_low-flat-81 =i 0 : Int
-                bs_acc_high-flat-82 =i sub#
-                                         map_insert_size-flat-68
+                map_insert_acc_keys-flat-61 =i flat-50-simpflat-100 : Array Time
+                map_insert_acc_vals-flat-62 =i flat-50-simpflat-101 : Array Int
+                map_insert_acc_bs_found-flat-64 =i False : Bool
+                map_insert_acc_bs_index-flat-63 =i -1 : Int
+                map_insert_loc_keys-flat-65 =r map_insert_acc_keys-flat-61
+                map_insert_size-flat-72 = Array_length#
+                                            map_insert_loc_keys-flat-65
+                bs_acc_found-flat-80 =i False : Bool
+                bs_acc_mid-flat-77 =i -1 : Int
+                bs_acc_ins-flat-79 =i -1 : Int
+                bs_acc_low-flat-85 =i 0 : Int
+                bs_acc_high-flat-86 =i sub#
+                                         map_insert_size-flat-72
                                          1 : Int
-                bs_acc_end-flat-83 =i False : Bool
+                bs_acc_end-flat-87 =i False : Bool
                 
-                while (bs_acc_end-flat-83 == False)
+                while (bs_acc_end-flat-87 == False)
                 {
-                    bs_loc_low-flat-79 =r bs_acc_low-flat-81
-                    bs_loc_high-flat-80 =r bs_acc_high-flat-82
+                    bs_loc_low-flat-83 =r bs_acc_low-flat-85
+                    bs_loc_high-flat-84 =r bs_acc_high-flat-86
                     
                     if (gt#
-                          bs_loc_low-flat-79
-                          bs_loc_high-flat-80)
+                          bs_loc_low-flat-83
+                          bs_loc_high-flat-84)
                     {
-                        bs_acc_end-flat-83 =w True
-                        bs_acc_ins-flat-75 =w bs_loc_low-flat-79
+                        bs_acc_end-flat-87 =w True
+                        bs_acc_ins-flat-79 =w bs_loc_low-flat-83
                     }
                     else
                     {
-                        simpflat-19 = add#
-                                        bs_loc_low-flat-79
-                                        bs_loc_high-flat-80
-                        simpflat-20 = doubleOfInt#
+                        simpflat-18 = add#
+                                        bs_loc_low-flat-83
+                                        bs_loc_high-flat-84
+                        simpflat-19 = doubleOfInt#
+                                        simpflat-18
+                        simpflat-20 = div#
                                         simpflat-19
-                        simpflat-21 = div#
-                                        simpflat-20
                                         2.0
-                        bs_acc_mid-flat-73 =w floor#
-                                                simpflat-21
-                        bs_loc_mid-flat-77 =r bs_acc_mid-flat-73
-                        bs_loc_x-flat-78 = unsafe_Array_index#
-                                             map_insert_loc_keys-flat-63
-                                             bs_loc_mid-flat-77
+                        bs_acc_mid-flat-77 =w floor#
+                                                simpflat-20
+                        bs_loc_mid-flat-81 =r bs_acc_mid-flat-77
+                        bs_loc_x-flat-82 = unsafe_Array_index#
+                                             map_insert_loc_keys-flat-65
+                                             bs_loc_mid-flat-81
                         
                         if (eq#
-                              bs_loc_x-flat-78
-                              simpflat-310)
+                              bs_loc_x-flat-82
+                              simpflat-318)
                         {
-                            bs_acc_end-flat-83 =w True
-                            bs_acc_found-flat-76 =w True
+                            bs_acc_end-flat-87 =w True
+                            bs_acc_found-flat-80 =w True
                         }
                         else
                         {
                             
                             if (lt#
-                                  bs_loc_x-flat-78
-                                  simpflat-310)
+                                  bs_loc_x-flat-82
+                                  simpflat-318)
                             {
-                                bs_acc_low-flat-81 =w add#
-                                                        bs_loc_mid-flat-77
+                                bs_acc_low-flat-85 =w add#
+                                                        bs_loc_mid-flat-81
                                                         1
                             }
                             else
                             {
-                                bs_acc_high-flat-82 =w sub#
-                                                         bs_loc_mid-flat-77
+                                bs_acc_high-flat-86 =w sub#
+                                                         bs_loc_mid-flat-81
                                                          1
                             }
                             
@@ -1540,173 +1505,164 @@ if (eq#
                     
                 }
                 
-                bs_loc_found-flat-71 =r bs_acc_found-flat-76
-                bs_loc_mid-flat-72 =r bs_acc_mid-flat-73
-                bs_loc_ins-flat-74 =r bs_acc_ins-flat-75
+                bs_loc_found-flat-75 =r bs_acc_found-flat-80
+                bs_loc_mid-flat-76 =r bs_acc_mid-flat-77
+                bs_loc_ins-flat-78 =r bs_acc_ins-flat-79
                 
                 if (eq#
-                      bs_loc_found-flat-71
+                      bs_loc_found-flat-75
                       True)
                 {
-                    map_insert_acc_bs_found-flat-62 =w True
-                    map_insert_acc_bs_index-flat-61 =w bs_loc_mid-flat-72
+                    map_insert_acc_bs_found-flat-64 =w True
+                    map_insert_acc_bs_index-flat-63 =w bs_loc_mid-flat-76
                 }
                 else
                 {
-                    map_insert_acc_bs_found-flat-62 =w False
-                    map_insert_acc_bs_index-flat-61 =w bs_loc_ins-flat-74
+                    map_insert_acc_bs_found-flat-64 =w False
+                    map_insert_acc_bs_index-flat-63 =w bs_loc_ins-flat-78
                 }
                 
-                flat-107 =r map_insert_acc_bs_found-flat-62
-                flat-108 =r map_insert_acc_bs_index-flat-61
+                flat-113 =r map_insert_acc_bs_found-flat-64
+                flat-114 =r map_insert_acc_bs_index-flat-63
                 
-                if (eq# flat-107 True)
+                if (eq# flat-113 True)
                 {
-                    map_insert_acc_vals-flat-60 =r map_insert_acc_vals-flat-60
-                    map_insert_acc_vals-flat-60 =w Array_put_immutable#
-                                                     map_insert_acc_vals-flat-60
-                                                     flat-108
-                                                     flat-106-simpflat-111
+                    copy_array-flat-91 =r map_insert_acc_vals-flat-62
+                    simpflat-21 = Array_length#
+                                    copy_array-flat-91
+                    
+                    if (ne# simpflat-21 0)
+                    {
+                        map_insert_acc_vals-flat-62 =w copy_array-flat-91
+                    }
+                    
+                    map_insert_acc_vals-flat-62 =r map_insert_acc_vals-flat-62
+                    map_insert_acc_vals-flat-62 =w Array_put_mutable#
+                                                     map_insert_acc_vals-flat-62
+                                                     flat-114
+                                                     flat-112-simpflat-118
                 }
                 else
                 {
-                    copy_array-flat-86 =r map_insert_acc_keys-flat-59
+                    copy_array-flat-90 =r map_insert_acc_keys-flat-61
                     simpflat-22 = Array_length#
-                                    copy_array-flat-86
+                                    copy_array-flat-90
                     
-                    if (eq# simpflat-22 0)
+                    if (ne# simpflat-22 0)
                     {
-                        
-                    }
-                    else
-                    {
-                        simpflat-23 = unsafe_Array_index#
-                                        copy_array-flat-86
-                                        0
-                        map_insert_acc_keys-flat-59 =w Array_put_immutable#
-                                                         copy_array-flat-86
-                                                         0
-                                                         simpflat-23
+                        map_insert_acc_keys-flat-61 =w copy_array-flat-90
                     }
                     
-                    copy_array-flat-87 =r map_insert_acc_vals-flat-60
-                    simpflat-24 = Array_length#
-                                    copy_array-flat-87
+                    flat-115 =r map_insert_acc_vals-flat-62
+                    simpflat-23 = Array_length#
+                                    flat-115
                     
-                    if (eq# simpflat-24 0)
+                    if (ne# simpflat-23 0)
                     {
-                        
-                    }
-                    else
-                    {
-                        simpflat-25 = unsafe_Array_index#
-                                        copy_array-flat-87
-                                        0
-                        map_insert_acc_vals-flat-60 =w Array_put_immutable#
-                                                         copy_array-flat-87
-                                                         0
-                                                         simpflat-25
+                        map_insert_acc_vals-flat-62 =w flat-115
                     }
                     
+                    map_insert_cpy_keys-flat-67 =r map_insert_acc_keys-flat-61
+                    flat-116 =r map_insert_acc_vals-flat-62
                     
-                    foreach (for_counter-flat-88 in map_insert_size-flat-68 .. flat-108)
+                    foreach (for_counter-flat-92 in map_insert_size-flat-72 .. flat-114)
                     {
-                        update_acc-flat-89 =r map_insert_acc_keys-flat-59
-                        simpflat-26 = sub#
-                                        for_counter-flat-88
+                        update_acc-flat-93 =r map_insert_acc_keys-flat-61
+                        simpflat-24 = sub#
+                                        for_counter-flat-92
                                         1
+                        simpflat-25 = unsafe_Array_index#
+                                        map_insert_cpy_keys-flat-67
+                                        simpflat-24
+                        map_insert_acc_keys-flat-61 =w Array_put_mutable#
+                                                         update_acc-flat-93
+                                                         for_counter-flat-92
+                                                         simpflat-25
+                        update_acc-flat-94 =r map_insert_acc_vals-flat-62
                         simpflat-27 = unsafe_Array_index#
-                                        map_insert_loc_keys-flat-63
-                                        simpflat-26
-                        map_insert_acc_keys-flat-59 =w Array_put_mutable#
-                                                         update_acc-flat-89
-                                                         for_counter-flat-88
+                                        flat-116
+                                        simpflat-24
+                        map_insert_acc_vals-flat-62 =w Array_put_mutable#
+                                                         update_acc-flat-94
+                                                         for_counter-flat-92
                                                          simpflat-27
-                        update_acc-flat-90 =r map_insert_acc_vals-flat-60
-                        simpflat-29 = unsafe_Array_index#
-                                        map_insert_loc_vals-flat-64
-                                        simpflat-26
-                        map_insert_acc_vals-flat-60 =w Array_put_mutable#
-                                                         update_acc-flat-90
-                                                         for_counter-flat-88
-                                                         simpflat-29
                     }
                     
-                    map_insert_acc_keys-flat-59 =r map_insert_acc_keys-flat-59
-                    map_insert_acc_keys-flat-59 =w Array_put_mutable#
-                                                     map_insert_acc_keys-flat-59
-                                                     flat-108
-                                                     simpflat-310
-                    map_insert_acc_vals-flat-60 =r map_insert_acc_vals-flat-60
-                    map_insert_acc_vals-flat-60 =w Array_put_mutable#
-                                                     map_insert_acc_vals-flat-60
-                                                     flat-108
-                                                     flat-106-simpflat-111
+                    map_insert_acc_keys-flat-61 =r map_insert_acc_keys-flat-61
+                    map_insert_acc_keys-flat-61 =w Array_put_mutable#
+                                                     map_insert_acc_keys-flat-61
+                                                     flat-114
+                                                     simpflat-318
+                    map_insert_acc_vals-flat-62 =r map_insert_acc_vals-flat-62
+                    map_insert_acc_vals-flat-62 =w Array_put_mutable#
+                                                     map_insert_acc_vals-flat-62
+                                                     flat-114
+                                                     flat-112-simpflat-118
                 }
                 
-                flat-109 =r map_insert_acc_keys-flat-59
-                flat-110 =r map_insert_acc_vals-flat-60
-                flat-56-simpflat-112 =w ExceptNotAnError
-                flat-56-simpflat-113 =w flat-109
-                flat-56-simpflat-114 =w flat-110
+                flat-117 =r map_insert_acc_keys-flat-61
+                flat-118 =r map_insert_acc_vals-flat-62
+                flat-58-simpflat-119 =w ExceptNotAnError
+                flat-58-simpflat-120 =w flat-117
+                flat-58-simpflat-121 =w flat-118
             }
             else
             {
-                flat-56-simpflat-112 =w flat-106-simpflat-110
-                flat-56-simpflat-113 =w unsafe_Array_create#
+                flat-58-simpflat-119 =w flat-112-simpflat-117
+                flat-58-simpflat-120 =w unsafe_Array_create#
                                           0
-                flat-56-simpflat-114 =w unsafe_Array_create#
+                flat-58-simpflat-121 =w unsafe_Array_create#
                                           0
             }
             
-            flat-56-simpflat-115 =r flat-56-simpflat-112
-            flat-56-simpflat-116 =r flat-56-simpflat-113
-            flat-56-simpflat-117 =r flat-56-simpflat-114
-            flat-51-simpflat-95 =w flat-56-simpflat-115
-            flat-51-simpflat-96 =w flat-56-simpflat-116
-            flat-51-simpflat-97 =w flat-56-simpflat-117
+            flat-58-simpflat-122 =r flat-58-simpflat-119
+            flat-58-simpflat-123 =r flat-58-simpflat-120
+            flat-58-simpflat-124 =r flat-58-simpflat-121
+            flat-53-simpflat-102 =w flat-58-simpflat-122
+            flat-53-simpflat-103 =w flat-58-simpflat-123
+            flat-53-simpflat-104 =w flat-58-simpflat-124
         }
         else
         {
-            flat-51-simpflat-95 =w flat-48-simpflat-92
-            flat-51-simpflat-96 =w unsafe_Array_create#
-                                     0
-            flat-51-simpflat-97 =w unsafe_Array_create#
-                                     0
+            flat-53-simpflat-102 =w flat-50-simpflat-99
+            flat-53-simpflat-103 =w unsafe_Array_create#
+                                      0
+            flat-53-simpflat-104 =w unsafe_Array_create#
+                                      0
         }
         
-        flat-51-simpflat-118 =r flat-51-simpflat-95
-        flat-51-simpflat-119 =r flat-51-simpflat-96
-        flat-51-simpflat-120 =r flat-51-simpflat-97
-        flat-48-simpflat-89 =w flat-51-simpflat-118
-        flat-48-simpflat-90 =w flat-51-simpflat-119
-        flat-48-simpflat-91 =w flat-51-simpflat-120
+        flat-53-simpflat-125 =r flat-53-simpflat-102
+        flat-53-simpflat-126 =r flat-53-simpflat-103
+        flat-53-simpflat-127 =r flat-53-simpflat-104
+        flat-50-simpflat-96 =w flat-53-simpflat-125
+        flat-50-simpflat-97 =w flat-53-simpflat-126
+        flat-50-simpflat-98 =w flat-53-simpflat-127
     }
     
-    flat-111-simpflat-121 =r flat-48-simpflat-89
-    flat-111-simpflat-122 =r flat-48-simpflat-90
-    flat-111-simpflat-123 =r flat-48-simpflat-91
-    flat-40-simpflat-86 =w flat-111-simpflat-121
-    flat-40-simpflat-87 =w flat-111-simpflat-122
-    flat-40-simpflat-88 =w flat-111-simpflat-123
+    flat-119-simpflat-128 =r flat-50-simpflat-96
+    flat-119-simpflat-129 =r flat-50-simpflat-97
+    flat-119-simpflat-130 =r flat-50-simpflat-98
+    flat-42-simpflat-93 =w flat-119-simpflat-128
+    flat-42-simpflat-94 =w flat-119-simpflat-129
+    flat-42-simpflat-95 =w flat-119-simpflat-130
 }
 else
 {
-    flat-40-simpflat-86 =w conv-34-simpflat-81
-    flat-40-simpflat-87 =w unsafe_Array_create#
+    flat-42-simpflat-93 =w conv-34-simpflat-88
+    flat-42-simpflat-94 =w unsafe_Array_create#
                              0
-    flat-40-simpflat-88 =w unsafe_Array_create#
+    flat-42-simpflat-95 =w unsafe_Array_create#
                              0
 }
 
-flat-40-simpflat-124 =r flat-40-simpflat-86
-flat-40-simpflat-125 =r flat-40-simpflat-87
-flat-40-simpflat-126 =r flat-40-simpflat-88
+flat-42-simpflat-131 =r flat-42-simpflat-93
+flat-42-simpflat-132 =r flat-42-simpflat-94
+flat-42-simpflat-133 =r flat-42-simpflat-95
 
 output repl:output : Sum Error (Map Time Int) =
-    flat-40-simpflat-124 : Error
-  , flat-40-simpflat-125 : Array Time
-  , flat-40-simpflat-126 : Array Int
+    flat-42-simpflat-131 : Error
+  , flat-42-simpflat-132 : Array Time
+  , flat-42-simpflat-133 : Array Int
 
 Core evaluation
 ---------------

--- a/icicle-compiler/test/test.hs
+++ b/icicle-compiler/test/test.hs
@@ -15,6 +15,7 @@ import qualified Icicle.Test.Core.Program.Condense
 
 import qualified Icicle.Test.Avalanche.EvalCommutes
 import qualified Icicle.Test.Avalanche.CheckCommutes
+import qualified Icicle.Test.Avalanche.Simp.Linear
 import qualified Icicle.Test.Avalanche.SimpCommutes
 import qualified Icicle.Test.Avalanche.Flatten
 import qualified Icicle.Test.Avalanche.Melt
@@ -96,6 +97,7 @@ avalanche =
     , Icicle.Test.Avalanche.Melt.tests
     , Icicle.Test.Avalanche.MeltPrim.tests
     , Icicle.Test.Avalanche.SimpCommutes.tests
+    , Icicle.Test.Avalanche.Simp.Linear.tests
     ]
 
 core :: TestSuite

--- a/icicle-source/src/Icicle/Source/Checker/Constraint.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Constraint.hs
@@ -171,13 +171,13 @@ constraintsQ env q
 
   -- Perform top-level discharge of any silly leftover Possibility or Temporality joins
   top = do
-   (q',_,cons) <- generateQ q env
+   (q',s,cons) <- generateQ q env
    case dischargeCS' dischargeC'toplevel cons of
     Left errs
      -> genHoistEither
       $ errorNoSuggestions (ErrorConstraintsNotSatisfied (annotOfQuery q) errs)
     Right (sub', cons')
-     -> let q'' = substTQ sub' q'
+     -> let q'' = substTQ (compose s sub') q'
         in  return (q'', cons')
 
 


### PR DESCRIPTION
Icicle is a pure language, but when it gets to C, its maps and arrays
are actually just C arrays.

This means that map insert, and array sort functions have to copy the
whole array to maintain pure semantics; but there are a lot of cases
when this copy won't change the program results and can be removed.

The idea here is that when an array is exclusively accessed in an affine
manner, then we don't actually need to clone it, and can instead act on
them destructively.

This pass performs copy elision when an array is provably not accessed
by a binding (which is really a pointer to the heap) which is not the
result of the copy or an alias of said copy – that is, there can't be any
usage of the name of the binding being copied or any other previously
known reference.

To do this, in a forwards pass we build a graph of aliases to arrays in
scope; and, lazily in a backwards pass, we build a usage map of all
bindings in scope.

Finally, if we encounter a write which just writes a copy of an array, and
no values which might share a reference are used after this, then we
delete the copy, and just use the original array.

It's hard to overstate how much better this can make queries which include
group operations, as it can lead to speed ups of more than 100% with far
smaller memory usage, especially for entities with a large number of events.

Compilation times are actually very good, looking at adding only ~5% to
the total compilation time.