### PR TITLE
Permit functions to demand pure Temporal modes.

### DIFF
--- a/icicle-compiler/test/cli/repl/t17-latest/expected
+++ b/icicle-compiler/test/cli/repl/t17-latest/expected
@@ -116,7 +116,7 @@ marge|[ 2
 ----
 
 repl:output :
-  Aggregate (Definitely (Array Int))
+  Aggregate (Definitely (Array (Sum ErrorT Int)))
 
 Core evaluation
 ---------------
@@ -134,7 +134,7 @@ marge|[ 0
 ----
 
 repl:output :
-  Aggregate (Definitely (Array Int))
+  Aggregate (Definitely (Array (Sum ErrorT Int)))
 
 Core evaluation
 ---------------
@@ -152,7 +152,7 @@ marge|[ 0
 ----
 
 repl:output :
-  Aggregate (Definitely (Array Int))
+  Aggregate (Definitely (Array (Sum ErrorT Int)))
 
 Core evaluation
 ---------------
@@ -170,7 +170,7 @@ marge|[ 0
 ----
 
 repl:output :
-  Aggregate (Definitely (Array Int))
+  Aggregate (Definitely (Array (Sum ErrorT Int)))
 
 Core evaluation
 ---------------


### PR DESCRIPTION
Because you can write a function which takes the initial value passed to a fold, we should allow functions to require a pure temporality. Previously we had an extra _ignore_ mode on the join if both expected and provided types, but now we lub these and require they lift to the expected mode.

Also improve type inference correctness for possibilities when definite modes are demanded. We don't enforce that a definite value is provided, but instead lift up the possible mode into the result if it is. This makes type inference more correct and consistent with the type inferred after inlining.

Unfortunately, this change for possibilities _would_ be wrong if we introduced the function "catch" or "unbox", which turns a possible mode into definite either.